### PR TITLE
Biblioteca de rànquing i selecció de parelles (#7)

### DIFF
--- a/backend/app/ranking/__init__.py
+++ b/backend/app/ranking/__init__.py
@@ -1,0 +1,21 @@
+"""Biblioteca de rànquing i selecció de parelles per a Arena Cat (tasca #7).
+
+Tres funcions públiques, una per pregunta de la tasca:
+
+- `select_next_task(session, category_code)`:
+      Quina és la propera parella de models a avaluar per a l'usuari?
+- `compute_ranking(session, category_code)`:
+      Quin és el rànquing actual dels models?
+- `assess_confidence(session, category_code)`:
+      Quina confiança tenim en el rànquing actual?
+
+Totes les funcions accepten una sessió SQLAlchemy oberta i un codi de
+categoria. Retornen diccionaris serialitzables a JSON; la microservei
+(tasca #6) els passa directament als endpoints de FastAPI.
+"""
+
+from app.ranking.confidence import assess_confidence
+from app.ranking.ranking import compute_ranking
+from app.ranking.sampler import select_next_task
+
+__all__ = ["assess_confidence", "compute_ranking", "select_next_task"]

--- a/backend/app/ranking/confidence.py
+++ b/backend/app/ranking/confidence.py
@@ -1,0 +1,205 @@
+"""Avalua la confiança del rànquing actual d'una categoria.
+
+La funció `assess_confidence` respon a la tercera pregunta de la
+tasca 7: hem arribat a prou avaluacions? Quina certesa tenim sobre el
+millor model?
+
+Mètode: bootstrap clusteritzat amb etiquetes fixes.
+
+1. Ajustem BT sobre totes les dades per identificar el millor actual.
+   Aquesta etiqueta queda CONGELADA per a totes les repliques.
+2. Re-mostrejem prompts sencers AMB reemplaçament (cluster bootstrap)
+   per respectar la dependència intra-prompt.
+3. Per cada replica, ajustem BT i calculem `delta = θ[best_fix] − max(θ[competidor])`.
+   El delta pot ser NEGATIU si en aquesta replica el millor perd.
+4. Reportem `p_best_is_best` (fracció de deltas > 0) i el CI 95% (percentils
+   2.5 i 97.5 dels deltas).
+
+Regla d'aturada operativa: el rànquing és estable si `ci_lo > 0`.
+
+Limitacions documentades a `docs/T7_ranking_design.md` §5.3:
+- Bootstrap clusteritzat amb 10 prompts té problemes de mostra petita
+  coneguts a la literatura.
+- No modelem la dependència a nivell de sessió (un votant que vota molt).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from sqlalchemy import select
+from sqlalchemy.orm import Session, aliased
+
+from app.models import Category, Prompt, Response, Vote, Winner
+from app.ranking.ranking import fit_bt
+
+
+def _load_clustered_votes(
+    session: Session, category_code: str
+) -> tuple[dict[int, list[tuple[str, str]]], list[str]]:
+    """Llegeix els vots decisius d'una categoria agrupats per prompt_id.
+
+    Retorna:
+        - mapping {prompt_id: [(guanyador, perdedor), ...]}
+        - llista de models únics observats.
+
+    Els empats i els 'neither' no entren al càlcul de confiança BT.
+    """
+    response_a = aliased(Response)
+    response_b = aliased(Response)
+    stmt = (
+        select(Vote.prompt_id, Vote.winner, response_a.model, response_b.model)
+        .join(Prompt, Vote.prompt_id == Prompt.id)
+        .join(Category, Prompt.category_id == Category.id)
+        .join(response_a, Vote.response_a_id == response_a.id)
+        .join(response_b, Vote.response_b_id == response_b.id)
+        .where(Category.code == category_code)
+    )
+    by_prompt: dict[int, list[tuple[str, str]]] = {}
+    seen_models: set[str] = set()
+    for prompt_id, winner, model_a, model_b in session.execute(stmt).all():
+        seen_models.add(model_a)
+        seen_models.add(model_b)
+        if winner == Winner.a:
+            by_prompt.setdefault(prompt_id, []).append((model_a, model_b))
+        elif winner == Winner.b:
+            by_prompt.setdefault(prompt_id, []).append((model_b, model_a))
+        # els empats i els neithers no s'inclouen al bootstrap BT.
+    return by_prompt, sorted(seen_models)
+
+
+def _bootstrap_deltas(
+    by_prompt: dict[int, list[tuple[str, str]]],
+    models: list[str],
+    best_model: str,
+    n_bootstrap: int,
+    seed: int,
+    alpha: float,
+) -> np.ndarray:
+    """Re-mostra prompts amb reemplaçament i retorna l'array de deltas."""
+    competitors = [m for m in models if m != best_model]
+    prompt_ids = list(by_prompt.keys())
+    n_prompts = len(prompt_ids)
+    rng = np.random.default_rng(seed)
+
+    deltas = np.empty(n_bootstrap)
+    for b in range(n_bootstrap):
+        sampled = rng.choice(prompt_ids, size=n_prompts, replace=True)
+        votes = [v for p in sampled for v in by_prompt[p]]
+        theta_b = fit_bt(votes, models, alpha=alpha)
+        deltas[b] = theta_b[best_model] - max(theta_b[c] for c in competitors)
+    return deltas
+
+
+def assess_confidence(
+    session: Session,
+    category_code: str,
+    n_bootstrap: int = 1000,
+    alpha: float = 0.01,
+    seed: int = 0,
+) -> dict:
+    """Avalua si tenim prou confiança per declarar un guanyador per categoria.
+
+    Pensada per ser cridada des de `GET /api/ranking` o `GET /api/stats` a la
+    microservei (tasca #6). Cost: ~5 segons (1000 ajustos BT). La microservei
+    HA DE cachejar el resultat — no es pot calcular en línia a cada petició.
+
+    Decisió: bootstrap clusteritzat amb etiquetes fixes.
+
+    Per què clusteritzat: dos vots sobre el mateix prompt no són
+    independents (comparteixen la dificultat i les peculiaritats del prompt).
+    Re-mostrejar prompts sencers, no vots individuals, respecta aquesta
+    dependència. Sense això, els CIs serien massa estrets ~2× (vegeu
+    `docs/T7_ranking_design.md` §5 i `analysis/dimensioning.py`).
+
+    Per què etiquetes fixes: ajustem BT una vegada sobre tot el dataset per
+    identificar el "millor actual". Aquesta etiqueta queda CONGELADA. A cada
+    replica del bootstrap, mesurem el gap del MATEIX model (no del millor
+    d'aquella replica). Així, si el rànquing és inestable, el gap surt
+    negatiu en algunes repliques — la inestabilitat es fa visible. La versió
+    "sort and take rank1−rank2" era incorrecta i ho amagava (gap forçat ≥ 0).
+
+    Mètriques retornades:
+        - `p_best_is_best`: fracció de repliques bootstrap on el best fix
+          encara és el millor. Útil per comunicar al públic ("guanya el 97%
+          del temps quan re-mostregem").
+        - `ci_lo`, `ci_hi`: percentils 2.5 i 97.5 del gap entre el best fix
+          i el millor competidor. Pot ser negatiu si el rànquing és inestable.
+        - `is_stable`: True si `ci_lo > 0`. Regla d'aturada operativa.
+
+    Limitacions (cal documentar-les públicament):
+        - Amb només ~10 prompts per categoria, el cluster bootstrap té
+          problemes coneguts de mostra petita; els CIs són honestos però
+          no màgics.
+        - No modelem la dependència a nivell de sessió (un votant que vota
+          molt podria distorsionar els resultats). S'abordarà a la v2 quan
+          hi hagi usuaris autenticats.
+
+    Args:
+        session: sessió SQLAlchemy ja oberta.
+        category_code: codi de la categoria (e.g. "correccio").
+        n_bootstrap: nombre de repliques del bootstrap. 1000 sol ser prou.
+        alpha: regularització L2 per a l'ajust BT (vegeu `ranking.fit_bt`).
+        seed: llavor per a reproduïbilitat.
+
+    Returns:
+        Diccionari amb la forma:
+
+        ```
+        {
+            "category_code": "correccio",
+            "best_model": "gemma-3-4b-it",
+            "n_prompts": 10,
+            "n_decisive_votes": 358,
+            "p_best_is_best": 0.97,    # fracció de repliques on best guanya
+            "ci_lo": 0.12,             # percentil 2.5 del delta
+            "ci_hi": 0.44,             # percentil 97.5 del delta
+            "is_stable": True,         # True si ci_lo > 0
+        }
+        ```
+
+        Si no hi ha prou vots o models per fer el bootstrap, retorna valors
+        per defecte amb `is_stable=False`.
+    """
+    by_prompt, models = _load_clustered_votes(session, category_code)
+    n_decisive = sum(len(v) for v in by_prompt.values())
+
+    if len(models) < 2 or n_decisive == 0:
+        return {
+            "category_code": category_code,
+            "best_model": None,
+            "n_prompts": len(by_prompt),
+            "n_decisive_votes": n_decisive,
+            "p_best_is_best": 0.0,
+            "ci_lo": 0.0,
+            "ci_hi": 0.0,
+            "is_stable": False,
+        }
+
+    # Pas 1: ajust complet → millor model amb etiqueta fixa.
+    all_decisive = [v for vs in by_prompt.values() for v in vs]
+    theta_hat = fit_bt(all_decisive, models, alpha=alpha)
+    best_model = max(theta_hat, key=theta_hat.get)
+
+    # Pas 2: bootstrap clusteritzat.
+    deltas = _bootstrap_deltas(
+        by_prompt=by_prompt,
+        models=models,
+        best_model=best_model,
+        n_bootstrap=n_bootstrap,
+        seed=seed,
+        alpha=alpha,
+    )
+
+    ci_lo, ci_hi = np.percentile(deltas, [2.5, 97.5])
+    p_best_is_best = float(np.mean(deltas > 0))
+
+    return {
+        "category_code": category_code,
+        "best_model": best_model,
+        "n_prompts": len(by_prompt),
+        "n_decisive_votes": n_decisive,
+        "p_best_is_best": round(p_best_is_best, 3),
+        "ci_lo": round(float(ci_lo), 4),
+        "ci_hi": round(float(ci_hi), 4),
+        "is_stable": bool(ci_lo > 0),
+    }

--- a/backend/app/ranking/ranking.py
+++ b/backend/app/ranking/ranking.py
@@ -1,0 +1,298 @@
+"""Calcula el rànquing dels models per categoria.
+
+La funció  `compute_ranking` retorna:
+
+- el millor model segons Bradley-Terry,
+- els skills BT (sumats a zero per identificabilitat),
+- la matriu bruta de win-rates per parella,
+- recomptes globals (vots decisius, empats, neithers),
+- detecció de cicles a la matriu bruta (per a n=3 és possible: A>B>C>A).
+
+Convencions:
+- Només els vots decisius (winner='a' o 'b') entren a l'ajust BT.
+- Els empats i els "neither" es reporten per separat per a transparència.
+- Skills sumats a zero; regularització L2 amb `alpha=0.01` per evitar
+  divergències en cas de separació completa.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+
+import numpy as np
+from scipy.optimize import minimize
+from scipy.special import expit, log_expit
+from sqlalchemy import select
+from sqlalchemy.orm import Session, aliased
+
+from app.models import Category, Prompt, Response, Vote, Winner
+
+# ---------------------------------------------------------------------------
+# Ajustador BT — el mateix que vam validar a `analysis/phase1/02_bt_fitter.py`.
+# ---------------------------------------------------------------------------
+
+
+def _negative_log_likelihood(
+    theta: np.ndarray,
+    winner_idx: np.ndarray,
+    loser_idx: np.ndarray,
+    alpha: float,
+) -> float:
+    """NLL regularitzada per a BT vectoritzada."""
+    diffs = theta[winner_idx] - theta[loser_idx]
+    log_likelihood = log_expit(diffs).sum()
+    penalty = alpha * (theta**2).sum()
+    return -log_likelihood + penalty
+
+
+def _gradient(
+    theta: np.ndarray,
+    winner_idx: np.ndarray,
+    loser_idx: np.ndarray,
+    alpha: float,
+) -> np.ndarray:
+    """Gradient analític de la NLL respecte a theta."""
+    diffs = theta[winner_idx] - theta[loser_idx]
+    residuals = 1.0 - expit(diffs)
+    grad = np.zeros_like(theta)
+    np.add.at(grad, winner_idx, -residuals)
+    np.add.at(grad, loser_idx, residuals)
+    grad += 2.0 * alpha * theta
+    return grad
+
+
+def fit_bt(
+    decisive_votes: list[tuple[str, str]],
+    models: list[str],
+    alpha: float = 0.01,
+) -> dict[str, float]:
+    """Ajusta Bradley-Terry per màxima versemblança amb sum-to-zero.
+
+    Args:
+        decisive_votes: llista de tuples (guanyador, perdedor) per a cada vot decisiu.
+        models: identificadors dels models, en ordre estable.
+        alpha: pes de la regularització L2.
+
+    Returns:
+        Diccionari {model: skill BT}. Els skills sumen zero.
+    """
+    if not decisive_votes:
+        return {m: 0.0 for m in models}
+    model_to_idx = {m: i for i, m in enumerate(models)}
+    winner_idx = np.array([model_to_idx[w] for w, _ in decisive_votes])
+    loser_idx = np.array([model_to_idx[loser] for _, loser in decisive_votes])
+    theta0 = np.zeros(len(models))
+    result = minimize(
+        _negative_log_likelihood,
+        theta0,
+        args=(winner_idx, loser_idx, alpha),
+        jac=_gradient,
+        method="L-BFGS-B",
+    )
+    theta = result.x - result.x.mean()
+    return dict(zip(models, theta, strict=True))
+
+
+# ---------------------------------------------------------------------------
+# Càrrega de vots d'una categoria + càlcul de la matriu
+# ---------------------------------------------------------------------------
+
+
+def _load_votes_for_category(session: Session, category_code: str) -> list[tuple[Winner, str, str]]:
+    """Llegeix els vots d'una categoria com a tuples (winner, model_a, model_b).
+
+    Fem JOIN doble amb la taula responses per obtenir els identificadors de
+    model (no els IDs de resposta), perquè el rànquing opera per model.
+    """
+    response_a = aliased(Response)
+    response_b = aliased(Response)
+    stmt = (
+        select(Vote.winner, response_a.model, response_b.model)
+        .join(Prompt, Vote.prompt_id == Prompt.id)
+        .join(Category, Prompt.category_id == Category.id)
+        .join(response_a, Vote.response_a_id == response_a.id)
+        .join(response_b, Vote.response_b_id == response_b.id)
+        .where(Category.code == category_code)
+    )
+    return list(session.execute(stmt).all())
+
+
+def _pairwise_stats(
+    raw: list[tuple[Winner, str, str]],
+    models: list[str],
+) -> list[dict]:
+    """Comptes per parella ordenada (a, b) amb a < b alfabèticament."""
+    pairs = [tuple(sorted(p)) for p in combinations(models, 2)]
+    counts = {p: {"wins_a": 0, "wins_b": 0, "ties": 0, "neither": 0} for p in pairs}
+    for winner, model_a, model_b in raw:
+        key = tuple(sorted((model_a, model_b)))
+        if key not in counts:
+            continue  # parella amb un model no esperat: ignora
+        if winner == Winner.tie:
+            counts[key]["ties"] += 1
+        elif winner == Winner.neither:
+            counts[key]["neither"] += 1
+        elif (winner == Winner.a and model_a == key[0]) or (
+            winner == Winner.b and model_b == key[0]
+        ):
+            counts[key]["wins_a"] += 1
+        else:
+            counts[key]["wins_b"] += 1
+
+    stats = []
+    for (a, b), c in counts.items():
+        decisive = c["wins_a"] + c["wins_b"]
+        win_rate_a = c["wins_a"] / decisive if decisive > 0 else None
+        stats.append(
+            {
+                "model_a": a,
+                "model_b": b,
+                "wins_a": c["wins_a"],
+                "wins_b": c["wins_b"],
+                "ties": c["ties"],
+                "neither": c["neither"],
+                "win_rate_a": win_rate_a,
+            }
+        )
+    return stats
+
+
+def _detect_cycle_3way(stats: list[dict]) -> tuple[bool, list[str]]:
+    """Detecta un cicle A>B>C>A a partir de les taxes brutes (només per n=3)."""
+    if len(stats) != 3:
+        return False, []
+    # Direcció: el guanyador de cada parella és qui té win_rate_a > 0.5
+    # (o model_b si win_rate_a < 0.5).
+    edges: dict[str, str] = {}
+    for s in stats:
+        if s["win_rate_a"] is None:
+            return False, []
+        winner = s["model_a"] if s["win_rate_a"] > 0.5 else s["model_b"]
+        loser = s["model_b"] if s["win_rate_a"] > 0.5 else s["model_a"]
+        edges[winner] = loser
+
+    if len(edges) != 3:
+        return False, []
+    # Cicle: cada model apunta a un altre i tots tornen al punt de partida.
+    start = next(iter(edges))
+    path = [start]
+    for _ in range(3):
+        path.append(edges[path[-1]])
+    return path[0] == path[-1], path
+
+
+def _models_for_category(
+    raw: list[tuple[Winner, str, str]],
+) -> list[str]:
+    """Extreu la llista única de models que apareixen als vots."""
+    seen = set()
+    for _, model_a, model_b in raw:
+        seen.add(model_a)
+        seen.add(model_b)
+    return sorted(seen)
+
+
+def compute_ranking(session: Session, category_code: str) -> dict:
+    """Calcula el rànquing actual d'una categoria.
+
+    Pensada per ser cridada des de `GET /api/ranking` a la microservei
+    (tasca #6). Cost: ~30 ms (un sol ajust BT sobre tots els vots de la
+    categoria). La microservei pot cachejar el resultat uns minuts.
+
+    No hi ha estat persistit: cada crida recalcula des de zero llegint
+    TOTS els vots de la base de dades. Això és intencional — qualsevol vot
+    afegit a `votes` es reflecteix al següent rànquing sense pas de sync.
+
+    Decisions clau:
+        - **BT per categoria**, no global. La pregunta del producte és
+          "quin model és millor a correcció / cultura / traducció", no un
+          rànquing únic.
+        - **Taxes brutes + BT**, no només BT. Per a n=3 models, el guany
+          de BT sobre la taxa bruta és modest (~30%); reportem totes dues
+          per transparència pública.
+        - **Empats i 'neither' es reporten per separat, mai entren a BT.**
+          Tie = "tots dos comparables"; neither = "tots dos fallits";
+          són senyals diferents, no equivalents.
+        - **Skills sumats a zero** per identificabilitat (BT és invariant
+          a desplaçaments). Només els *gaps* són significatius.
+        - **Detecció de cicles** A>B>C>A a les taxes brutes: per a n=3
+          és possible i informatiu (heterogeneïtat real entre prompts),
+          no un bug. BT el suavitzaria; nosaltres el reportem.
+
+    Args:
+        session: sessió SQLAlchemy ja oberta.
+        category_code: codi de la categoria (e.g. "correccio").
+
+    Returns:
+        Diccionari amb la forma:
+
+        ```
+        {
+            "category_code": "correccio",
+            "n_votes_total": 390,
+            "n_votes_decisive": 358,
+            "n_ties": 23,
+            "n_neither": 9,
+            "models": ["gemma-3-4b-it", "qwen-3.5-9b", "salamandra-7b-instruct"],
+            "best_model": "gemma-3-4b-it",
+            "bt_skills": {"gemma-3-4b-it": 0.27, "qwen-3.5-9b": -0.04, ...},
+            "raw_pairwise": [
+                {"model_a": ..., "model_b": ..., "wins_a": ..., ...},
+            ],
+            "cycle_detected": False,
+            "cycle_path": [],
+        }
+        ```
+
+        Si no hi ha vots a la categoria, `best_model` és None i `bt_skills`
+        és buit.
+    """
+    raw = _load_votes_for_category(session, category_code)
+    if not raw:
+        return {
+            "category_code": category_code,
+            "n_votes_total": 0,
+            "n_votes_decisive": 0,
+            "n_ties": 0,
+            "n_neither": 0,
+            "models": [],
+            "best_model": None,
+            "bt_skills": {},
+            "raw_pairwise": [],
+            "cycle_detected": False,
+            "cycle_path": [],
+        }
+
+    models = _models_for_category(raw)
+    n_total = len(raw)
+    n_ties = sum(1 for w, _, _ in raw if w == Winner.tie)
+    n_neither = sum(1 for w, _, _ in raw if w == Winner.neither)
+    n_decisive = n_total - n_ties - n_neither
+
+    # Per BT només els vots decisius.
+    decisive: list[tuple[str, str]] = []
+    for winner, model_a, model_b in raw:
+        if winner == Winner.a:
+            decisive.append((model_a, model_b))
+        elif winner == Winner.b:
+            decisive.append((model_b, model_a))
+
+    bt_skills = fit_bt(decisive, models, alpha=0.01)
+    best_model = max(bt_skills, key=bt_skills.get) if bt_skills else None
+
+    raw_pairwise = _pairwise_stats(raw, models)
+    cycle, cycle_path = _detect_cycle_3way(raw_pairwise)
+
+    return {
+        "category_code": category_code,
+        "n_votes_total": n_total,
+        "n_votes_decisive": n_decisive,
+        "n_ties": n_ties,
+        "n_neither": n_neither,
+        "models": models,
+        "best_model": best_model,
+        "bt_skills": {m: round(s, 4) for m, s in bt_skills.items()},
+        "raw_pairwise": raw_pairwise,
+        "cycle_detected": cycle,
+        "cycle_path": cycle_path if cycle else [],
+    }

--- a/backend/app/ranking/sampler.py
+++ b/backend/app/ranking/sampler.py
@@ -9,6 +9,8 @@ Estratègia per defecte: **quota-balanced randomization**.
   cel·la.
 - Tria uniformement entre les cel·les que actualment tenen menys vots.
 - Randomitza l'ordre A/B per evitar biaix de posició.
+- Si es passa `session_id`, exclou les cel·les en les quals aquesta sessió
+  ja ha votat per evitar repeticions.
 
 Aquesta estratègia és preferible a la iid uniform (que genera variància
 Poisson entre cel·les) i no pateix crítica de "Leaderboard Illusion"
@@ -24,7 +26,7 @@ from itertools import combinations
 
 import numpy as np
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 
 from app.models import Category, Prompt, Response, Vote
 
@@ -55,8 +57,6 @@ def _existing_vote_counts(session: Session, prompt_ids: list[int]) -> Counter:
     if not prompt_ids:
         return Counter()
     # Llegim els vots i fem el join amb responses per obtenir els models.
-    from sqlalchemy.orm import aliased
-
     response_a = aliased(Response)
     response_b = aliased(Response)
     stmt = (
@@ -72,9 +72,35 @@ def _existing_vote_counts(session: Session, prompt_ids: list[int]) -> Counter:
     return counts
 
 
+def _cells_voted_by_session(
+    session: Session, prompt_ids: list[int], session_id: str
+) -> set[tuple[int, str, str]]:
+    """Retorna les cel·les (prompt_id, model_a, model_b) on `session_id` ja ha votat.
+
+    Servirà per excloure-les del proper sampling i no demanar el mateix dues
+    vegades a la mateixa persona.
+    """
+    if not prompt_ids:
+        return set()
+    response_a = aliased(Response)
+    response_b = aliased(Response)
+    stmt = (
+        select(Vote.prompt_id, response_a.model, response_b.model)
+        .join(response_a, Vote.response_a_id == response_a.id)
+        .join(response_b, Vote.response_b_id == response_b.id)
+        .where(Vote.prompt_id.in_(prompt_ids))
+        .where(Vote.session_id == session_id)
+    )
+    voted: set[tuple[int, str, str]] = set()
+    for prompt_id, model_a, model_b in session.execute(stmt).all():
+        voted.add((prompt_id, *sorted((model_a, model_b))))
+    return voted
+
+
 def select_next_task(
     session: Session,
     category_code: str,
+    session_id: str | None = None,
     seed: int | None = None,
 ) -> dict | None:
     """Tria la propera tasca a mostrar a un avaluador.
@@ -91,6 +117,13 @@ def select_next_task(
         - Quan totes les cel·les igualen recompte, esdevé aleatori uniforme.
         - Randomitza l'ordre A/B per evitar biaix de posició.
 
+    Si es passa `session_id`, exclou les cel·les on aquesta sessió ja ha
+    votat: una mateixa persona no veurà dos cops la mateixa (prompt, parella).
+    Quan una sessió ja ha votat a TOTES les cel·les de la categoria, retorna
+    None — la microservei interpretarà això com "aquest avaluador ja ha
+    completat aquesta categoria, mostra-li una altra cosa o agraeix-li la
+    contribució".
+
     Per què NO iid uniforme: amb un pressupost petit (133 vots/cel·la a la
     Fita 1), iid genera variància Poisson que deixa cel·les amb el doble de
     vots que altres. La validació empírica a `analysis/phase1/04_samplers_comparison.py`
@@ -104,6 +137,9 @@ def select_next_task(
     Args:
         session: sessió SQLAlchemy ja oberta.
         category_code: codi de la categoria (e.g. "correccio", "reformulacio").
+        session_id: identificador anònim de la sessió de l'usuari. Si es
+            proporciona, exclou les cel·les en les quals aquesta sessió ja
+            ha votat. Si és None, no es filtra per sessió.
         seed: opcional, per reproduïbilitat als tests.
 
     Returns:
@@ -121,7 +157,10 @@ def select_next_task(
         }
         ```
 
-        Si la categoria no té prompts amb almenys dues respostes, retorna None.
+        Retorna None en dos casos:
+            - La categoria no té cap prompt amb almenys dues respostes.
+            - `session_id` ha votat a totes les cel·les disponibles.
+
         Els identificadors de model (`model_a`, `model_b`) NO es retornen:
         l'avaluació és cega. La microservei pot recuperar-los des de Response
         si li cal registrar el mapping al gravar el vot.
@@ -144,10 +183,21 @@ def select_next_task(
     if not cells:
         return None
 
+    prompt_ids = [p.id for p, _ in prompts_with_responses]
+
+    # Si tenim session_id, excloem les cel·les que aquesta sessió ja ha votat.
+    # Si la sessió ja ha votat a totes les cel·les, retornem None per indicar
+    # que aquest avaluador ja ha completat la categoria.
+    if session_id is not None:
+        already_voted = _cells_voted_by_session(session, prompt_ids, session_id)
+        cells = [c for c in cells if c not in already_voted]
+        if not cells:
+            return None
+
     # Busquem el recompte mínim de vots i recollim TOTES les cel·les empatades a aquell mínim.
     # Després triem una uniformement a l'atzar: la combinació "empatats al mínim + atzar"
     # és la que evita biaixos d'ordre i fa convergir els recomptes a valors igualats.
-    counts = _existing_vote_counts(session, [p.id for p, _ in prompts_with_responses])
+    counts = _existing_vote_counts(session, prompt_ids)
     min_count = min(counts.get(c, 0) for c in cells)
     underfilled = [c for c in cells if counts.get(c, 0) == min_count]
     chosen = underfilled[int(rng.integers(len(underfilled)))]

--- a/backend/app/ranking/sampler.py
+++ b/backend/app/ranking/sampler.py
@@ -1,0 +1,168 @@
+"""Tria la propera tasca a mostrar a un avaluador.
+
+`select_next_task` retorna un diccionari amb el prompt, les dues respostes
+i la informació necessària perquè la microservei la mostri a l'usuari.
+
+Estratègia per defecte: **quota-balanced randomization**.
+
+- Considera cada combinació (prompt, parella ordenada de models) com una
+  cel·la.
+- Tria uniformement entre les cel·les que actualment tenen menys vots.
+- Randomitza l'ordre A/B per evitar biaix de posició.
+
+Aquesta estratègia és preferible a la iid uniform (que genera variància
+Poisson entre cel·les) i no pateix crítica de "Leaderboard Illusion"
+(els pesos no depenen de cap rànquing acumulat).
+
+Vegeu `docs/T7_ranking_design.md` §4 per a la motivació completa.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from itertools import combinations
+
+import numpy as np
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models import Category, Prompt, Response, Vote
+
+
+def _load_prompts_and_responses(
+    session: Session, category_code: str
+) -> list[tuple[Prompt, dict[str, Response]]]:
+    """Llegeix els prompts de la categoria amb totes les seves respostes.
+
+    Retorna una llista de tuples (prompt, {model: response}).
+    """
+    stmt = (
+        select(Prompt)
+        .join(Category, Prompt.category_id == Category.id)
+        .where(Category.code == category_code)
+    )
+    prompts = session.scalars(stmt).all()
+    out = []
+    for prompt in prompts:
+        responses_by_model = {r.model: r for r in prompt.responses}
+        if len(responses_by_model) >= 2:
+            out.append((prompt, responses_by_model))
+    return out
+
+
+def _existing_vote_counts(session: Session, prompt_ids: list[int]) -> Counter:
+    """Compta vots existents per (prompt_id, model_a, model_b) en parella ordenada."""
+    if not prompt_ids:
+        return Counter()
+    # Llegim els vots i fem el join amb responses per obtenir els models.
+    from sqlalchemy.orm import aliased
+
+    response_a = aliased(Response)
+    response_b = aliased(Response)
+    stmt = (
+        select(Vote.prompt_id, response_a.model, response_b.model)
+        .join(response_a, Vote.response_a_id == response_a.id)
+        .join(response_b, Vote.response_b_id == response_b.id)
+        .where(Vote.prompt_id.in_(prompt_ids))
+    )
+    counts: Counter = Counter()
+    for prompt_id, model_a, model_b in session.execute(stmt).all():
+        key = (prompt_id, *sorted((model_a, model_b)))
+        counts[key] += 1
+    return counts
+
+
+def select_next_task(
+    session: Session,
+    category_code: str,
+    seed: int | None = None,
+) -> dict | None:
+    """Tria la propera tasca a mostrar a un avaluador.
+
+    Pensada per ser cridada des de `GET /api/task` a la microservei (tasca #6).
+    Cada crida és independent: només llegeix recomptes de vots a la base de
+    dades; no ajusta cap model i no manté estat. Cost: ~10 ms.
+
+    Decisió: estratègia **quota-balanced randomization**.
+
+        - Una cel·la és un trio (prompt, parella ordenada de models).
+        - A cada crida, busca les cel·les que actualment empaten al recompte
+          mínim de vots i en tria una uniformement a l'atzar.
+        - Quan totes les cel·les igualen recompte, esdevé aleatori uniforme.
+        - Randomitza l'ordre A/B per evitar biaix de posició.
+
+    Per què NO iid uniforme: amb un pressupost petit (133 vots/cel·la a la
+    Fita 1), iid genera variància Poisson que deixa cel·les amb el doble de
+    vots que altres. La validació empírica a `analysis/phase1/04_samplers_comparison.py`
+    mostra que quota-balanced arriba a un rànquing estable amb ~2.5× menys
+    vots. Vegeu `docs/T7_ranking_design.md` §4 per la motivació completa.
+
+    Per què NO depèn del rànquing actual: això la fa robusta a la crítica
+    "Leaderboard Illusion" (Singh et al. 2025) — no hi ha bucle entre vots
+    acumulats i futur sampling.
+
+    Args:
+        session: sessió SQLAlchemy ja oberta.
+        category_code: codi de la categoria (e.g. "correccio", "reformulacio").
+        seed: opcional, per reproduïbilitat als tests.
+
+    Returns:
+        Diccionari amb la forma:
+
+        ```
+        {
+            "category_code": "correccio",
+            "prompt_id": 42,
+            "prompt_text": "Corregeix aquest text...",
+            "response_a_id": 100,
+            "response_a_text": "...",
+            "response_b_id": 101,
+            "response_b_text": "...",
+        }
+        ```
+
+        Si la categoria no té prompts amb almenys dues respostes, retorna None.
+        Els identificadors de model (`model_a`, `model_b`) NO es retornen:
+        l'avaluació és cega. La microservei pot recuperar-los des de Response
+        si li cal registrar el mapping al gravar el vot.
+    """
+    rng = np.random.default_rng(seed)
+    prompts_with_responses = _load_prompts_and_responses(session, category_code)
+    if not prompts_with_responses:
+        return None
+
+    # Construïm totes les cel·les possibles: (prompt_id, parella ordenada de models).
+    cells: list[tuple[int, str, str]] = []
+    cell_to_responses: dict[tuple[int, str, str], tuple[Prompt, Response, Response]] = {}
+    for prompt, responses in prompts_with_responses:
+        models = sorted(responses.keys())
+        for model_a, model_b in combinations(models, 2):
+            cell = (prompt.id, model_a, model_b)
+            cells.append(cell)
+            cell_to_responses[cell] = (prompt, responses[model_a], responses[model_b])
+
+    if not cells:
+        return None
+
+    # Busquem el recompte mínim de vots i recollim TOTES les cel·les empatades a aquell mínim.
+    # Després triem una uniformement a l'atzar: la combinació "empatats al mínim + atzar"
+    # és la que evita biaixos d'ordre i fa convergir els recomptes a valors igualats.
+    counts = _existing_vote_counts(session, [p.id for p, _ in prompts_with_responses])
+    min_count = min(counts.get(c, 0) for c in cells)
+    underfilled = [c for c in cells if counts.get(c, 0) == min_count]
+    chosen = underfilled[int(rng.integers(len(underfilled)))]
+    prompt, response_a, response_b = cell_to_responses[chosen]
+
+    # Randomitzem l'ordre A/B per evitar biaix de posició.
+    if rng.random() < 0.5:
+        response_a, response_b = response_b, response_a
+
+    return {
+        "category_code": category_code,
+        "prompt_id": prompt.id,
+        "prompt_text": prompt.text,
+        "response_a_id": response_a.id,
+        "response_a_text": response_a.text,
+        "response_b_id": response_b.id,
+        "response_b_text": response_b.text,
+    }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,6 +10,8 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "pydantic-settings>=2.0",
     "pyyaml>=6.0",
+    "numpy>=1.26",
+    "scipy>=1.11",
 ]
 
 [dependency-groups]
@@ -17,6 +19,7 @@ dev = [
     "pytest>=8.0",
     "ruff>=0.6",
     "pre-commit>=3.7",
+    "choix>=0.3",
 ]
 
 [tool.uv]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "pydantic-settings>=2.0",
     "pyyaml>=6.0",
-    "numpy>=1.26",
-    "scipy>=1.11",
+    "numpy==2.5.0",
+    "scipy==1.18.0",
 ]
 
 [dependency-groups]
@@ -19,7 +19,7 @@ dev = [
     "pytest>=8.0",
     "ruff>=0.6",
     "pre-commit>=3.7",
-    "choix>=0.3",
+    "choix==0.4.1",
 ]
 
 [tool.uv]

--- a/backend/tests/test_confidence.py
+++ b/backend/tests/test_confidence.py
@@ -1,0 +1,122 @@
+"""Tests de `app.ranking.confidence.assess_confidence`.
+
+Comprovem que el bootstrap clusteritzat amb etiquetes fixes és calibrat:
+declara estable un rànquing realment estable i rebutja un cas de coin-flip.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.models import Category, Prompt, Response, Vote, Winner
+from app.ranking.confidence import assess_confidence
+
+MODELS = ["gemma-3-4b-it", "qwen-3.5-9b", "salamandra-7b-instruct"]
+
+
+def _category(session, code="correccio"):
+    return session.scalar(select(Category).where(Category.code == code))
+
+
+def _seed_prompts(session, category_code, n_prompts):
+    cat = _category(session, category_code)
+    out = []
+    for i in range(n_prompts):
+        prompt = Prompt(
+            version="vtest",
+            code=f"{category_code}-conf-{i:02d}",
+            category_id=cat.id,
+            text=f"Prompt {i}",
+        )
+        session.add(prompt)
+        session.flush()
+        responses = {}
+        for m in MODELS:
+            r = Response(prompt=prompt, model=m, text=f"Resposta de {m}")
+            session.add(r)
+            responses[m] = r
+        session.flush()
+        out.append((prompt, responses))
+    return out
+
+
+def _vote(session, prompt, response_a, response_b, winner):
+    session.add(
+        Vote(
+            prompt_id=prompt.id,
+            response_a_id=response_a.id,
+            response_b_id=response_b.id,
+            winner=winner,
+        )
+    )
+
+
+def test_assess_confidence_empty_category(session):
+    """Sense vots, retorna valors per defecte amb is_stable=False."""
+    result = assess_confidence(session, "correccio")
+    assert result["best_model"] is None
+    assert result["n_decisive_votes"] == 0
+    assert result["is_stable"] is False
+
+
+def test_assess_confidence_clear_winner_is_stable(session):
+    """Si gemma guanya sempre, el rànquing és estable amb alta confiança."""
+    prompts = _seed_prompts(session, "correccio", n_prompts=5)
+    gemma, qwen, salamandra = MODELS
+    for prompt, r in prompts:
+        # gemma guanya 8 vegades cada parella que l'inclou.
+        for _ in range(8):
+            _vote(session, prompt, r[gemma], r[qwen], Winner.a)
+            _vote(session, prompt, r[gemma], r[salamandra], Winner.a)
+        # qwen vs salamandra: 4-4, no aporta direcció.
+        for _ in range(4):
+            _vote(session, prompt, r[qwen], r[salamandra], Winner.a)
+            _vote(session, prompt, r[qwen], r[salamandra], Winner.b)
+
+    # Bootstrap rapid per als tests (200 repliques en lloc de 1000).
+    result = assess_confidence(session, "correccio", n_bootstrap=200, seed=42)
+    assert result["best_model"] == gemma
+    assert result["p_best_is_best"] >= 0.95
+    assert result["is_stable"] is True
+    assert result["ci_lo"] > 0
+
+
+def test_assess_confidence_coin_flip_is_unstable(session):
+    """Si totes les parelles són 50/50, el rànquing no és estable."""
+    prompts = _seed_prompts(session, "traduccio", n_prompts=5)
+    gemma, qwen, salamandra = MODELS
+    for prompt, r in prompts:
+        # 6-6 per a cada parella → veredicte real és tie.
+        for _ in range(6):
+            _vote(session, prompt, r[gemma], r[qwen], Winner.a)
+            _vote(session, prompt, r[gemma], r[qwen], Winner.b)
+            _vote(session, prompt, r[gemma], r[salamandra], Winner.a)
+            _vote(session, prompt, r[gemma], r[salamandra], Winner.b)
+            _vote(session, prompt, r[qwen], r[salamandra], Winner.a)
+            _vote(session, prompt, r[qwen], r[salamandra], Winner.b)
+
+    result = assess_confidence(session, "traduccio", n_bootstrap=200, seed=42)
+    # El best és arbitrari (sampling noise), però el rànquing NO ha de ser estable.
+    assert result["is_stable"] is False
+    # ci_lo hauria de ser proper a zero o negatiu.
+    assert result["ci_lo"] <= 0.05
+
+
+def test_assess_confidence_ignores_ties_and_neither(session):
+    """Empats i neithers no contribueixen al bootstrap BT."""
+    prompts = _seed_prompts(session, "reformulacio", n_prompts=2)
+    gemma, qwen, salamandra = MODELS
+    for prompt, r in prompts:
+        # 4 decisius (gemma guanya), més 5 empats i 3 neithers que han d'ignorar-se.
+        for _ in range(4):
+            _vote(session, prompt, r[gemma], r[qwen], Winner.a)
+            _vote(session, prompt, r[gemma], r[salamandra], Winner.a)
+            _vote(session, prompt, r[qwen], r[salamandra], Winner.a)
+        for _ in range(5):
+            _vote(session, prompt, r[gemma], r[qwen], Winner.tie)
+        for _ in range(3):
+            _vote(session, prompt, r[gemma], r[qwen], Winner.neither)
+
+    result = assess_confidence(session, "reformulacio", n_bootstrap=200, seed=42)
+    # 3 parelles × 4 decisius × 2 prompts = 24 vots decisius.
+    assert result["n_decisive_votes"] == 24

--- a/backend/tests/test_integration_scale.py
+++ b/backend/tests/test_integration_scale.py
@@ -131,8 +131,8 @@ def test_60pct_winner_is_correctly_identified(session):
 
     Configuració:
         - Categoria: correcció.
-        - 5 prompts × 3 parelles = 15 respostes.
-        - 600 vots simulats (40 vots/cel·la), distribuïts pel sampler quota-balanced.
+        - 5 prompts × 3 parelles = 15 cel·les.
+        - 1800 vots simulats (~120 vots/cel·la), distribuïts pel sampler quota-balanced.
         - gemma guanya amb probabilitat 0.6 quan és a la parella.
         - qwen vs salamandra: 50/50 (cap dels dos és el favorit).
 
@@ -146,7 +146,10 @@ def test_60pct_winner_is_correctly_identified(session):
     _seed_prompts_with_responses(session, "correccio", n_prompts=5)
     favored_model = "gemma-3-4b-it"
     win_prob = 0.60
-    n_votes = 600
+    # 5 prompts × 3 parelles = 15 cel·les. Amb 1800 vots són ~120 per cel·la:
+    # més que suficient perquè la CI de rank1-vs-rank2 quedi clarament positiva
+    # amb un avantatge plantat del 60% i només 5 clusters de prompt.
+    n_votes = 1800
 
     # Ni el RNG ens atura. Som i serem
     rng = np.random.default_rng(seed=1714)
@@ -450,7 +453,7 @@ def test_categories_are_independent_at_scale(session):
         - Categoria A = correcció, gemma guanya al 60%.
         - Categoria B = traducció, qwen guanya al 60%.
         - Categoria C = reformulació, cap vot.
-        - Els 800 vots totals s'alternen entre A i B (400 cadascuna).
+        - Els 1600 vots totals s'alternen entre A i B (800 cadascuna).
         - Els vots de la mateixa parella no es reciclen entre categories:
           els prompts són diferents (`correccio-scale-*` vs `traduccio-scale-*`).
 
@@ -470,7 +473,10 @@ def test_categories_are_independent_at_scale(session):
         "traduccio": "qwen-3.5-9b",
     }
     win_prob = 0.60
-    n_votes_per_category = 400
+    # 5 prompts × 3 parelles per categoria = 15 cel·les. 800 vots/categoria →
+    # ~53 vots/cel·la; suficient perquè la CI del gap del guanyador a
+    # cada categoria quedi clarament positiva amb només 5 clusters.
+    n_votes_per_category = 800
     n_votes_total = n_votes_per_category * len(plan)
 
     # Ni el RNG ens atura. Som i serem

--- a/backend/tests/test_integration_scale.py
+++ b/backend/tests/test_integration_scale.py
@@ -834,3 +834,147 @@ def test_ranking_adapts_when_new_prompts_added_mid_campaign(session):
         f"Rànquing inestable després d'afegir prompts. "
         f"CI=[{final_confidence['ci_lo']}, {final_confidence['ci_hi']}]"
     )
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — apareix una nova categoria a mig camí; el sistema s'hi adapta.
+# ---------------------------------------------------------------------------
+
+
+def test_new_category_added_mid_campaign_is_independent(session):
+    """Afegim una nova categoria (`cultura`) després d'haver votat a `correccio`.
+
+    Escenari real: el projecte decideix afegir una categoria nova (per exemple,
+    "cultura" — no seedejada al `conftest`). El sistema ha de:
+        - Retornar None si es demana una tasca d'una categoria sense prompts.
+        - Un cop hi ha prompts a la nova categoria, servir-los amb normalitat.
+        - Mantenir els rànquings de les categories velles intactes.
+        - Calcular un rànquing independent per a la nova categoria.
+        - No contaminar les altres categories existents (`reformulacio`
+          continua buida).
+
+    Configuració:
+        - Fase 1: 5 prompts × 3 models a `correccio`. 600 vots amb gemma
+          al 60%.
+        - Comprovem: sampling de `cultura` retorna None (encara no té prompts).
+        - Creem la categoria `cultura` (no és a `INITIAL_CATEGORIES`) i
+          afegim 3 prompts × 3 respostes.
+        - Fase 2: 600 vots a `cultura` amb salamandra al 60%.
+
+    Comprovacions finals:
+        - `correccio` conserva els seus 600 vots i gemma com a millor model.
+        - `cultura` té 600 vots i salamandra com a millor model.
+        - Els guanyadors són diferents (no hi ha fuga entre categories).
+        - Ambdós rànquings són estables.
+        - `reformulacio` continua buida.
+    """
+    _assert_running_against_test_database(session)
+    _seed_prompts_with_responses(session, "correccio", n_prompts=5)
+    n_votes_per_phase = 600
+    win_prob = 0.60
+    correccio_winner = "gemma-3-4b-it"
+    cultura_winner = "salamandra-7b-instruct"
+
+    # Ni el RNG ens atura. Som i serem
+    rng = np.random.default_rng(seed=1714)
+
+    # ---- Fase 1: només `correccio` existeix com a categoria amb prompts ----
+    for i in range(n_votes_per_phase):
+        task = select_next_task(session, "correccio", seed=i)
+        assert task is not None, f"Fase 1 iteració {i}: sampler ha retornat None"
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+        winner = _planted_winner(
+            rng, response_a.model, response_b.model, correccio_winner, win_prob
+        )
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"phase1-cat-{i % 20}",
+        )
+
+    # Snapshot Fase 1: correccio identifica gemma com a millor.
+    snap_correccio = compute_ranking(session, "correccio")
+    assert snap_correccio["best_model"] == correccio_winner
+    assert snap_correccio["n_votes_total"] == n_votes_per_phase
+
+    # ---- Verifiquem que una categoria SENSE prompts retorna None al sampler ----
+    # (`cultura` encara no existeix a la BD; el sampler ha de gestionar-ho
+    # amb elegància.)
+    task_empty = select_next_task(session, "cultura", seed=42)
+    assert task_empty is None, (
+        "Sampler ha retornat una tasca per a una categoria sense prompts. Hauria de retornar None."
+    )
+
+    # ---- Creem la categoria `cultura` i li afegim 3 prompts × 3 respostes ----
+    session.add(
+        Category(
+            code="cultura",
+            name="Cultura",
+            description="Preguntes sobre cultura catalana.",
+        )
+    )
+    session.flush()
+    _seed_prompts_with_responses(session, "cultura", n_prompts=3)
+
+    # ---- Fase 2: votem a `cultura` amb salamandra com a guanyadora plantada ----
+    for j in range(n_votes_per_phase):
+        i = n_votes_per_phase + j
+        task = select_next_task(session, "cultura", seed=i)
+        assert task is not None, f"Fase 2 iteració {j}: sampler ha retornat None"
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+        winner = _planted_winner(rng, response_a.model, response_b.model, cultura_winner, win_prob)
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"phase2-cat-{j % 20}",
+        )
+
+    # ---- Comprovacions finals ----
+    final_correccio = compute_ranking(session, "correccio")
+    final_cultura = compute_ranking(session, "cultura")
+    final_reformulacio = compute_ranking(session, "reformulacio")
+
+    # 1) correccio no s'ha alterat: mateixos vots, mateix guanyador.
+    assert final_correccio["n_votes_total"] == n_votes_per_phase, (
+        f"correcció ha canviat el recompte de vots: {final_correccio['n_votes_total']}"
+    )
+    assert final_correccio["best_model"] == correccio_winner, (
+        f"correcció ha canviat de guanyador: {final_correccio['best_model']}"
+    )
+
+    # 2) cultura identifica salamandra com a millor.
+    assert final_cultura["n_votes_total"] == n_votes_per_phase
+    assert final_cultura["best_model"] == cultura_winner, (
+        f"Esperat {cultura_winner} a cultura, obtingut {final_cultura['best_model']}. "
+        f"Skills: {final_cultura['bt_skills']}"
+    )
+
+    # 3) Els guanyadors de les dues categories són diferents (sense fuga).
+    assert final_correccio["best_model"] != final_cultura["best_model"]
+
+    # 4) Ambdós rànquings són estables.
+    conf_correccio = assess_confidence(session, "correccio", n_bootstrap=200, seed=1714)
+    conf_cultura = assess_confidence(session, "cultura", n_bootstrap=200, seed=1714)
+    assert conf_correccio["is_stable"] is True, (
+        f"correcció inestable després d'introduir cultura. "
+        f"CI=[{conf_correccio['ci_lo']}, {conf_correccio['ci_hi']}]"
+    )
+    assert conf_cultura["is_stable"] is True, (
+        f"cultura inestable. CI=[{conf_cultura['ci_lo']}, {conf_cultura['ci_hi']}]"
+    )
+
+    # 5) reformulacio continua buida — les altres categories no la contaminen.
+    assert final_reformulacio["n_votes_total"] == 0
+    assert final_reformulacio["best_model"] is None
+    assert final_reformulacio["bt_skills"] == {}
+    assert final_reformulacio["raw_pairwise"] == []

--- a/backend/tests/test_integration_scale.py
+++ b/backend/tests/test_integration_scale.py
@@ -854,23 +854,28 @@ def test_new_category_added_mid_campaign_is_independent(session):
           continua buida).
 
     Configuració:
-        - Fase 1: 5 prompts × 3 models a `correccio`. 600 vots amb gemma
-          al 60%.
+        - Fase 1: 5 prompts × 3 models a `correccio`. 1800 vots amb gemma
+          al 60% (~120 vots/cel·la per obtenir un rànquing clarament estable).
         - Comprovem: sampling de `cultura` retorna None (encara no té prompts).
         - Creem la categoria `cultura` (no és a `INITIAL_CATEGORIES`) i
           afegim 3 prompts × 3 respostes.
-        - Fase 2: 600 vots a `cultura` amb salamandra al 60%.
+        - Fase 2: 800 vots a `cultura` amb salamandra al 60% (3 prompts ×
+          3 parelles = 9 cel·les → ~89 vots/cel·la, prou generós).
 
     Comprovacions finals:
-        - `correccio` conserva els seus 600 vots i gemma com a millor model.
-        - `cultura` té 600 vots i salamandra com a millor model.
+        - `correccio` conserva els seus 1800 vots i gemma com a millor model.
+        - `cultura` té 800 vots i salamandra com a millor model.
         - Els guanyadors són diferents (no hi ha fuga entre categories).
         - Ambdós rànquings són estables.
         - `reformulacio` continua buida.
     """
     _assert_running_against_test_database(session)
     _seed_prompts_with_responses(session, "correccio", n_prompts=5)
-    n_votes_per_phase = 600
+    # Fase 1 (correcció, 5 prompts × 3 parelles = 15 cel·les): 1800 vots per
+    # tenir ~120 vots/cel·la i que la CI clusteritzada del gap sigui clarament
+    # positiva amb només 5 clusters — mateixa lliçó que Test 1 i Test 4.
+    n_votes_phase1 = 1800
+    n_votes_phase2 = 800
     win_prob = 0.60
     correccio_winner = "gemma-3-4b-it"
     cultura_winner = "salamandra-7b-instruct"
@@ -879,7 +884,7 @@ def test_new_category_added_mid_campaign_is_independent(session):
     rng = np.random.default_rng(seed=1714)
 
     # ---- Fase 1: només `correccio` existeix com a categoria amb prompts ----
-    for i in range(n_votes_per_phase):
+    for i in range(n_votes_phase1):
         task = select_next_task(session, "correccio", seed=i)
         assert task is not None, f"Fase 1 iteració {i}: sampler ha retornat None"
 
@@ -900,7 +905,7 @@ def test_new_category_added_mid_campaign_is_independent(session):
     # Snapshot Fase 1: correccio identifica gemma com a millor.
     snap_correccio = compute_ranking(session, "correccio")
     assert snap_correccio["best_model"] == correccio_winner
-    assert snap_correccio["n_votes_total"] == n_votes_per_phase
+    assert snap_correccio["n_votes_total"] == n_votes_phase1
 
     # ---- Verifiquem que una categoria SENSE prompts retorna None al sampler ----
     # (`cultura` encara no existeix a la BD; el sampler ha de gestionar-ho
@@ -922,8 +927,8 @@ def test_new_category_added_mid_campaign_is_independent(session):
     _seed_prompts_with_responses(session, "cultura", n_prompts=3)
 
     # ---- Fase 2: votem a `cultura` amb salamandra com a guanyadora plantada ----
-    for j in range(n_votes_per_phase):
-        i = n_votes_per_phase + j
+    for j in range(n_votes_phase2):
+        i = n_votes_phase1 + j
         task = select_next_task(session, "cultura", seed=i)
         assert task is not None, f"Fase 2 iteració {j}: sampler ha retornat None"
 
@@ -945,7 +950,7 @@ def test_new_category_added_mid_campaign_is_independent(session):
     final_reformulacio = compute_ranking(session, "reformulacio")
 
     # 1) correccio no s'ha alterat: mateixos vots, mateix guanyador.
-    assert final_correccio["n_votes_total"] == n_votes_per_phase, (
+    assert final_correccio["n_votes_total"] == n_votes_phase1, (
         f"correcció ha canviat el recompte de vots: {final_correccio['n_votes_total']}"
     )
     assert final_correccio["best_model"] == correccio_winner, (
@@ -953,7 +958,7 @@ def test_new_category_added_mid_campaign_is_independent(session):
     )
 
     # 2) cultura identifica salamandra com a millor.
-    assert final_cultura["n_votes_total"] == n_votes_per_phase
+    assert final_cultura["n_votes_total"] == n_votes_phase2
     assert final_cultura["best_model"] == cultura_winner, (
         f"Esperat {cultura_winner} a cultura, obtingut {final_cultura['best_model']}. "
         f"Skills: {final_cultura['bt_skills']}"

--- a/backend/tests/test_integration_scale.py
+++ b/backend/tests/test_integration_scale.py
@@ -1,0 +1,830 @@
+"""Tests d'integració a escala per a la biblioteca de rànquing.
+
+Aquests tests fan córrer el pipeline complet — sampler → vots → DB →
+compute_ranking → assess_confidence — sobre escenaris realistes amb
+dades plantades, per detectar que tot encaixa quan creix el volum.
+
+Tots els tests són deterministes (llavors fixes) perquè es puguin
+executar a la CI sense flakiness. Cada escenari planta una "veritat"
+i comprova que el sistema la descobreix.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from sqlalchemy import select
+
+from app.models import Category, Prompt, Response, Vote, Winner
+from app.ranking.confidence import assess_confidence
+from app.ranking.ranking import compute_ranking
+from app.ranking.sampler import select_next_task
+
+MODELS = ["gemma-3-4b-it", "qwen-3.5-9b", "salamandra-7b-instruct"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers compartits per tots els tests d'aquest fitxer.
+# ---------------------------------------------------------------------------
+
+
+def _category(session, code):
+    return session.scalar(select(Category).where(Category.code == code))
+
+
+def _seed_prompts_with_responses(session, category_code, n_prompts):
+    """Crea n_prompts en una categoria, cadascun amb una resposta per cada model."""
+    cat = _category(session, category_code)
+    out = []
+    for i in range(n_prompts):
+        prompt = Prompt(
+            version="vtest",
+            code=f"{category_code}-scale-{i:02d}",
+            category_id=cat.id,
+            text=f"Prompt {i} a {category_code}",
+        )
+        session.add(prompt)
+        session.flush()
+        responses = {}
+        for m in MODELS:
+            r = Response(prompt=prompt, model=m, text=f"Resposta de {m} a {prompt.code}")
+            session.add(r)
+            responses[m] = r
+        session.flush()
+        out.append((prompt, responses))
+    return out
+
+
+def _planted_winner(rng, model_a, model_b, favored_model, win_prob):
+    """Retorna 'a' o 'b' segons una probabilitat plantada.
+
+    Si `favored_model` és en la parella, guanya amb `win_prob`.
+    Si no hi és (parella entre no favorits), el resultat és 50/50.
+    """
+    if favored_model == model_a:
+        return Winner.a if rng.random() < win_prob else Winner.b
+    if favored_model == model_b:
+        return Winner.b if rng.random() < win_prob else Winner.a
+    # Parella sense el favorit: 50/50.
+    return Winner.a if rng.random() < 0.5 else Winner.b
+
+
+def _record_vote(db_session, prompt_id, response_a_id, response_b_id, winner, session_id):
+    """Insereix un vot a la base de dades de tests."""
+    db_session.add(
+        Vote(
+            prompt_id=prompt_id,
+            response_a_id=response_a_id,
+            response_b_id=response_b_id,
+            winner=winner,
+            session_id=session_id,
+        )
+    )
+    db_session.flush()
+
+
+def _assert_running_against_test_database(db_session):
+    """Cinturó de seguretat: refusa córrer contra una base de dades que no sigui de tests.
+
+    La fixture `session` del conftest ja apunta a `arena_cat_test`, però
+    comprovem-ho explícitament a cada test d'integració per defensa en
+    profunditat. Si algú modifica el conftest per error i fa que els tests
+    apuntin a producció, aquesta assertion ho atura abans d'inserir res.
+    """
+    db_name = db_session.bind.engine.url.database
+    assert db_name.endswith("_test"), (
+        f"REFUSANT executar el test contra la base '{db_name}'. "
+        f"Aquest test només pot córrer contra una base de dades acabada en '_test'."
+    )
+
+
+def _planted_winner_with_noise(
+    rng, model_a, model_b, favored_model, win_prob, tie_rate, neither_rate
+):
+    """Com _planted_winner, però introdueix empats i 'neither' amb probabilitats fixes.
+
+    Args:
+        rng: numpy default_rng.
+        model_a, model_b: identificadors dels dos models de la parella.
+        favored_model: el model que volem afavorir entre vots decisius.
+        win_prob: probabilitat que favored_model guanyi quan és a la parella.
+        tie_rate: probabilitat que un vot sigui empat.
+        neither_rate: probabilitat que un vot sigui 'neither'.
+
+    El resultat és estocàstic; la reproduïbilitat ve donada per la llavor del rng.
+    """
+    roll = rng.random()
+    if roll < tie_rate:
+        return Winner.tie
+    if roll < tie_rate + neither_rate:
+        return Winner.neither
+    # Vot decisiu: reutilitzem la lògica de _planted_winner.
+    return _planted_winner(rng, model_a, model_b, favored_model, win_prob)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — un model preferit al 60% és identificat correctament.
+# ---------------------------------------------------------------------------
+
+
+def test_60pct_winner_is_correctly_identified(session):
+    """Plantem gemma com a favorita al 60%. El pipeline ha d'identificar-la com a millor.
+
+    Configuració:
+        - Categoria: correcció.
+        - 5 prompts × 3 parelles = 15 respostes.
+        - 600 vots simulats (40 vots/cel·la), distribuïts pel sampler quota-balanced.
+        - gemma guanya amb probabilitat 0.6 quan és a la parella.
+        - qwen vs salamandra: 50/50 (cap dels dos és el favorit).
+
+    Comprovacions:
+        - `compute_ranking` reporta gemma com a `best_model`.
+        - El skill BT de gemma és estrictament superior als dels altres.
+        - `assess_confidence` reporta `is_stable=True` (el rànquing és sòlid).
+        - `p_best_is_best` és alt (≥ 0.95).
+    """
+    _assert_running_against_test_database(session)
+    _seed_prompts_with_responses(session, "correccio", n_prompts=5)
+    favored_model = "gemma-3-4b-it"
+    win_prob = 0.60
+    n_votes = 600
+
+    # Ni el RNG ens atura. Som i serem
+    rng = np.random.default_rng(seed=1714)
+
+    for i in range(n_votes):
+        # Cada crida al sampler es passa amb una llavor diferent perquè
+        # la randomització dels empats al recompte mínim cobreixi totes les cel·les.
+        task = select_next_task(session, "correccio", seed=i)
+        assert task is not None, f"Sampler ha retornat None a la iteració {i}"
+
+        # Identifiquem quins models hi ha a la parella mostrada.
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+
+        # Decidim el guanyador segons la veritat plantada.
+        winner = _planted_winner(rng, response_a.model, response_b.model, favored_model, win_prob)
+
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"scale-test-{i % 30}",  # 30 sessions diferents
+        )
+
+    # Pas final: comprovem que el pipeline descobreix la veritat plantada.
+    ranking = compute_ranking(session, "correccio")
+    confidence = assess_confidence(session, "correccio", n_bootstrap=200, seed=1714)
+
+    # gemma ha de ser la millor.
+    assert ranking["best_model"] == favored_model, (
+        f"Esperat best_model={favored_model}, obtingut {ranking['best_model']}. "
+        f"Skills: {ranking['bt_skills']}"
+    )
+    assert confidence["best_model"] == favored_model
+
+    # El skill de gemma ha de ser estrictament superior als altres.
+    skills = ranking["bt_skills"]
+    for other in MODELS:
+        if other == favored_model:
+            continue
+        assert skills[favored_model] > skills[other], (
+            f"Skill de {favored_model} ({skills[favored_model]}) no supera "
+            f"el de {other} ({skills[other]})"
+        )
+
+    # El rànquing ha de ser estable amb 600 vots i un avantatge plantat del 60%.
+    assert confidence["is_stable"] is True, (
+        f"Rànquing inestable amb un guanyador clar plantat. "
+        f"CI=[{confidence['ci_lo']}, {confidence['ci_hi']}], "
+        f"p_best_is_best={confidence['p_best_is_best']}"
+    )
+
+    # La confiança que el millor actual sigui realment el millor ha de ser alta.
+    assert confidence["p_best_is_best"] >= 0.95, (
+        f"p_best_is_best={confidence['p_best_is_best']} massa baix per a un escenari "
+        f"amb un guanyador plantat al 60%"
+    )
+
+    # No hi ha d'haver cap cicle: gemma guanya tothom, no es pot tancar A>B>C>A.
+    assert ranking["cycle_detected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — molts empats i 'neither' no distorsionen BT.
+# ---------------------------------------------------------------------------
+
+
+def test_high_tie_and_neither_rates_dont_distort_bt(session):
+    """Plantem un guanyador clar enmig de molt soroll d'empats i 'neithers'.
+
+    Aquesta prova garanteix que la nostra política — descartar empats i
+    'neithers' del càlcul BT i només reportar-los a part — és sòlida.
+    Si algú "millorés" el codi comptant els empats com a 0.5/0.5, aquesta
+    prova fallaria: el guanyador plantat perdria el seu avantatge.
+
+    Configuració:
+        - Categoria: traducció.
+        - 5 prompts × 3 parelles = 15 cel·les.
+        - 800 vots simulats. Després del soroll:
+            · ~30% empats (Winner.tie).
+            · ~15% 'neithers' (Winner.neither).
+            · ~55% decisius — d'aquests, gemma guanya al 60% quan és a la parella.
+        - Total decisius esperat: ~440 (≈ 29 per cel·la).
+
+    Comprovacions:
+        - `best_model == gemma` malgrat el soroll.
+        - Els recomptes `n_ties` i `n_neither` cauen a la franja esperada.
+        - El rànquing és estable (`is_stable=True`).
+        - El skill BT de gemma és estrictament superior al dels altres.
+    """
+    _assert_running_against_test_database(session)
+    _seed_prompts_with_responses(session, "traduccio", n_prompts=5)
+    favored_model = "gemma-3-4b-it"
+    win_prob = 0.60
+    tie_rate = 0.30
+    neither_rate = 0.15
+    n_votes = 800
+
+    # Ni el RNG ens atura. Som i serem
+    rng = np.random.default_rng(seed=1714)
+
+    for i in range(n_votes):
+        task = select_next_task(session, "traduccio", seed=i)
+        assert task is not None, f"Sampler ha retornat None a la iteració {i}"
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+
+        winner = _planted_winner_with_noise(
+            rng=rng,
+            model_a=response_a.model,
+            model_b=response_b.model,
+            favored_model=favored_model,
+            win_prob=win_prob,
+            tie_rate=tie_rate,
+            neither_rate=neither_rate,
+        )
+
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"scale-test-noise-{i % 30}",
+        )
+
+    ranking = compute_ranking(session, "traduccio")
+    confidence = assess_confidence(session, "traduccio", n_bootstrap=200, seed=1714)
+
+    # 1) Els empats i 'neithers' han arribat a la franja esperada.
+    #    Donem un marge de ±5 punts percentuals respecte al pla.
+    tie_fraction = ranking["n_ties"] / ranking["n_votes_total"]
+    neither_fraction = ranking["n_neither"] / ranking["n_votes_total"]
+    assert abs(tie_fraction - tie_rate) < 0.05, (
+        f"Fracció d'empats {tie_fraction:.2%} massa lluny del plantat {tie_rate:.0%}"
+    )
+    assert abs(neither_fraction - neither_rate) < 0.05, (
+        f"Fracció de 'neither' {neither_fraction:.2%} massa lluny del plantat {neither_rate:.0%}"
+    )
+
+    # 2) El recompte de decisius coincideix amb la resta dels vots.
+    assert (
+        ranking["n_votes_decisive"]
+        == ranking["n_votes_total"] - ranking["n_ties"] - ranking["n_neither"]
+    )
+
+    # 3) Malgrat el soroll, gemma continua sent la millor.
+    assert ranking["best_model"] == favored_model, (
+        f"BT s'ha distorsionat: esperat {favored_model}, obtingut {ranking['best_model']}. "
+        f"Skills: {ranking['bt_skills']}"
+    )
+
+    # 4) El skill de gemma supera estrictament els altres.
+    skills = ranking["bt_skills"]
+    for other in MODELS:
+        if other == favored_model:
+            continue
+        assert skills[favored_model] > skills[other], (
+            f"Skill de {favored_model} ({skills[favored_model]}) no supera "
+            f"el de {other} ({skills[other]}) sota soroll"
+        )
+
+    # 5) El rànquing és estable: BT confia en el guanyador encara que el 45% dels
+    #    vots no aporta direcció.
+    assert confidence["is_stable"] is True, (
+        f"Rànquing inestable sota soroll d'empats/'neithers'. "
+        f"CI=[{confidence['ci_lo']}, {confidence['ci_hi']}], "
+        f"p_best_is_best={confidence['p_best_is_best']}"
+    )
+
+    # 6) p_best_is_best alt: la confiança no es desploma per la presència de soroll.
+    assert confidence["p_best_is_best"] >= 0.90, (
+        f"p_best_is_best={confidence['p_best_is_best']} massa baix sota soroll"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — moltes sessions entrellaçades; cap sessió no veu dues vegades la
+#          mateixa (prompt, parella).
+# ---------------------------------------------------------------------------
+
+
+def test_no_session_repeats_a_pair_in_multi_session_campaign(session):
+    """30 sessions voten alhora. Cap sessió no pot veure la mateixa cel·la dues vegades.
+
+    Aquest test cobreix el que els tests unitaris de `test_sampler.py` no
+    poden capturar: el comportament del sampler quan moltes sessions
+    independents comparteixen la mateixa base de dades i alternen els seus
+    vots. Si el filtre per `session_id` patís un error subtil (p.ex.,
+    oblidar la clàusula WHERE i barrejar vots de totes les sessions),
+    aquest escenari el detectaria.
+
+    Configuració:
+        - Categoria: reformulació.
+        - 5 prompts × 3 parelles = 15 cel·les.
+        - 30 sessions actives, cadascuna fent ~20 vots (600 vots totals).
+        - Les sessions s'alternen: vot 1 = sessio-0, vot 2 = sessio-1, ...
+          vot 30 = sessio-29, vot 31 = sessio-0 amb la BD ja modificada
+          per les 30 anteriors.
+
+    Invariants:
+        - Cada sessió no veu mai dues vegades la mateixa (prompt, parella).
+        - Cada sessió toca, com a màxim, 15 cel·les diferents (límit
+          natural: el nombre total de cel·les disponibles).
+        - Quan una sessió arriba al límit, el sampler retorna None per a
+          aquella sessió (i les altres no en queden afectades).
+    """
+    _assert_running_against_test_database(session)
+    _seed_prompts_with_responses(session, "reformulacio", n_prompts=5)
+    n_sessions = 30
+    n_votes = 600
+    favored_model = "gemma-3-4b-it"
+    win_prob = 0.60
+
+    # Ni el RNG ens atura. Som i serem
+    rng = np.random.default_rng(seed=1714)
+
+    # Per a cada sessió, mantenim un set de cel·les que ja ha vist.
+    # Si en algun moment el sampler retorna una cel·la repetida, fallem.
+    cells_seen_by_session: dict[str, set[tuple[int, str, str]]] = {
+        f"sessio-{s:02d}": set() for s in range(n_sessions)
+    }
+    skipped_full_sessions = 0
+
+    for i in range(n_votes):
+        session_id = f"sessio-{i % n_sessions:02d}"
+
+        task = select_next_task(session, "reformulacio", session_id=session_id, seed=i)
+
+        # Si la sessió ja ha completat totes les cel·les, el sampler retorna None.
+        # Comptem aquests casos per assegurar-nos que el límit es respecta de manera neta.
+        if task is None:
+            skipped_full_sessions += 1
+            assert len(cells_seen_by_session[session_id]) == 15, (
+                f"Sampler ha retornat None per a {session_id} però la sessió només "
+                f"ha vist {len(cells_seen_by_session[session_id])} cel·les (de 15)"
+            )
+            continue
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+        cell = (task["prompt_id"], *sorted((response_a.model, response_b.model)))
+
+        # INVARIANT CRÍTIC: aquesta sessió no ha vist mai aquesta cel·la.
+        assert cell not in cells_seen_by_session[session_id], (
+            f"VIOLACIÓ: la sessió {session_id} ha rebut una cel·la repetida {cell}. "
+            f"Aquest vot és el número {i}; la sessió ja havia vist "
+            f"{len(cells_seen_by_session[session_id])} cel·les."
+        )
+        cells_seen_by_session[session_id].add(cell)
+
+        winner = _planted_winner(rng, response_a.model, response_b.model, favored_model, win_prob)
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=session_id,
+        )
+
+    # Comprovacions post-campanya:
+    # 1) Cada sessió ha vist ≤ 15 cel·les úniques (no podria veure'n més).
+    for sid, seen in cells_seen_by_session.items():
+        assert len(seen) <= 15, (
+            f"La sessió {sid} ha vist {len(seen)} cel·les úniques (>15, impossible)"
+        )
+
+    # 2) Amb 30 sessions repartint-se 600 vots, cada sessió rep ~20 vots.
+    #    Però com que només hi ha 15 cel·les, algunes sessions hauran arribat
+    #    al sostre i hauran rebut None. Comprovem que això és coherent.
+    total_unique_cells_seen = sum(len(s) for s in cells_seen_by_session.values())
+    assert total_unique_cells_seen + skipped_full_sessions == n_votes, (
+        f"No quadra: vots útils ({total_unique_cells_seen}) + sessions plenes "
+        f"({skipped_full_sessions}) ≠ total ({n_votes})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — categories independents: guanyadors diferents no es contaminen.
+# ---------------------------------------------------------------------------
+
+
+def test_categories_are_independent_at_scale(session):
+    """Plantem guanyadors diferents a categories diferents. No hi ha contaminació.
+
+    Aquesta prova detecta la fuga entre categories. Si algú modifiqués les
+    consultes SQL i oblidés filtrar per `category_code`, els vots d'una
+    categoria influirien el rànquing d'una altra. Com que aquí plantem
+    gemma com a guanyadora de correcció i qwen com a guanyadora de
+    traducció, qualsevol fuga faria fallar les asserts.
+
+    També comprovem que una tercera categoria (reformulació), que no rep
+    cap vot, retorna un rànquing buit amb `best_model=None` — no ha de
+    ser mai contaminada per les altres.
+
+    Configuració:
+        - Categoria A = correcció, gemma guanya al 60%.
+        - Categoria B = traducció, qwen guanya al 60%.
+        - Categoria C = reformulació, cap vot.
+        - Els 800 vots totals s'alternen entre A i B (400 cadascuna).
+        - Els vots de la mateixa parella no es reciclen entre categories:
+          els prompts són diferents (`correccio-scale-*` vs `traduccio-scale-*`).
+
+    Comprovacions:
+        - `best_model` de correcció és gemma; de traducció és qwen.
+        - Els skills BT ho confirmen a cada categoria.
+        - Els dos rànquings són estables.
+        - Els recomptes de vots són els que hem plantat a cada categoria.
+        - Reformulació retorna una estructura buida coherent.
+    """
+    _assert_running_against_test_database(session)
+    _seed_prompts_with_responses(session, "correccio", n_prompts=5)
+    _seed_prompts_with_responses(session, "traduccio", n_prompts=5)
+
+    plan = {
+        "correccio": "gemma-3-4b-it",
+        "traduccio": "qwen-3.5-9b",
+    }
+    win_prob = 0.60
+    n_votes_per_category = 400
+    n_votes_total = n_votes_per_category * len(plan)
+
+    # Ni el RNG ens atura. Som i serem
+    rng = np.random.default_rng(seed=1714)
+
+    categories_cycle = list(plan.keys())
+
+    for i in range(n_votes_total):
+        # Alternem categories a cada iteració; així cap `select_next_task` no rep
+        # cap ajuda estranya per haver-se cridat repetidament sobre la mateixa BD.
+        category_code = categories_cycle[i % len(categories_cycle)]
+        favored_model = plan[category_code]
+
+        task = select_next_task(session, category_code, seed=i)
+        assert task is not None, (
+            f"Sampler ha retornat None a la iteració {i} (categoria={category_code})"
+        )
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+
+        winner = _planted_winner(rng, response_a.model, response_b.model, favored_model, win_prob)
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"cross-cat-{i % 30}",
+        )
+
+    # 1) Cada categoria ha rebut exactament els vots que li tocaven.
+    for category_code in plan:
+        ranking = compute_ranking(session, category_code)
+        assert ranking["n_votes_total"] == n_votes_per_category, (
+            f"La categoria {category_code} té {ranking['n_votes_total']} vots "
+            f"(esperats {n_votes_per_category}). Possible fuga entre categories."
+        )
+
+    # 2) Cada categoria identifica el seu propi guanyador; els guanyadors són
+    #    DIFERENTS (si es barregessin, tots dos serien iguals).
+    ranking_correccio = compute_ranking(session, "correccio")
+    ranking_traduccio = compute_ranking(session, "traduccio")
+
+    assert ranking_correccio["best_model"] == plan["correccio"], (
+        f"Correcció: esperat {plan['correccio']}, obtingut {ranking_correccio['best_model']}"
+    )
+    assert ranking_traduccio["best_model"] == plan["traduccio"], (
+        f"Traducció: esperat {plan['traduccio']}, obtingut {ranking_traduccio['best_model']}"
+    )
+    assert ranking_correccio["best_model"] != ranking_traduccio["best_model"], (
+        "Els guanyadors haurien de ser diferents; si són iguals, hi ha "
+        "contaminació entre categories."
+    )
+
+    # 3) A cada categoria, el skill del guanyador supera els dels altres.
+    for category_code, ranking in [
+        ("correccio", ranking_correccio),
+        ("traduccio", ranking_traduccio),
+    ]:
+        favored = plan[category_code]
+        skills = ranking["bt_skills"]
+        for other in MODELS:
+            if other == favored:
+                continue
+            assert skills[favored] > skills[other], (
+                f"[{category_code}] Skill de {favored} ({skills[favored]}) no supera "
+                f"el de {other} ({skills[other]})"
+            )
+
+    # 4) Els dos rànquings són estables.
+    for category_code in plan:
+        confidence = assess_confidence(session, category_code, n_bootstrap=200, seed=1714)
+        assert confidence["is_stable"] is True, (
+            f"[{category_code}] rànquing inestable amb 400 vots i un guanyador plantat. "
+            f"CI=[{confidence['ci_lo']}, {confidence['ci_hi']}]"
+        )
+
+    # 5) Reformulació no ha rebut cap vot: retorna una estructura buida coherent
+    #    i cap dels vots d'altres categories la contamina.
+    ranking_reformulacio = compute_ranking(session, "reformulacio")
+    assert ranking_reformulacio["n_votes_total"] == 0
+    assert ranking_reformulacio["best_model"] is None
+    assert ranking_reformulacio["bt_skills"] == {}
+    assert ranking_reformulacio["raw_pairwise"] == []
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — un nou model apareix a mig camí i el sistema s'hi adapta.
+# ---------------------------------------------------------------------------
+
+
+def test_ranking_adapts_when_new_model_added_mid_campaign(session):
+    """Fase 1: gemma guanya contra els altres 2. Fase 2: apareix un 4t model dominant.
+
+    A Fita 2 se n'incorporaran més models sense buidar la BD. Aquest test
+    verifica que:
+        - `compute_ranking` descobreix dinàmicament els models que apareixen
+          a la BD (no és una llista fixa al codi).
+        - El sampler comença a servir cel·les amb el nou model tan bon punt
+          hi ha respostes disponibles.
+        - `assess_confidence` gestiona 4 models sense trencar-se.
+        - Les votacions prèvies no queden corrompudes; només s'afegeix
+          informació nova.
+
+    Configuració:
+        - Categoria: correcció.
+        - 5 prompts × 3 models = 15 respostes inicials.
+        - Fase 1 (vots 1..300): gemma guanya al 60% quan és a la parella,
+          els altres 50/50. Snapshot: gemma és la millor amb 3 models.
+        - Introduïm un 4t model, `another-model-4b`, amb resposta a cadascun
+          dels 5 prompts.
+        - Fase 2 (vots 301..800): el nou model guanya al 70% contra qualsevol.
+          Snapshot final: el nou model és el millor amb 4 models.
+
+    Comprovacions:
+        - Snapshot Fase 1: 3 models al rànquing, gemma és la millor.
+        - Post-Fase 2: 4 models al rànquing, `another-model-4b` és la millor,
+          gemma queda com a segona.
+        - El total de vots és 800 exactes.
+        - El rànquing final és estable.
+    """
+    _assert_running_against_test_database(session)
+    seeded = _seed_prompts_with_responses(session, "correccio", n_prompts=5)
+    n_votes_phase1 = 300
+    n_votes_phase2 = 500
+    win_prob_gemma = 0.60
+    win_prob_newcomer = 0.70
+    newcomer = "another-model-4b"
+
+    # Ni el RNG ens atura. Som i serem
+    rng = np.random.default_rng(seed=1714)
+
+    # ---- Fase 1: només els 3 models inicials ----
+    for i in range(n_votes_phase1):
+        task = select_next_task(session, "correccio", seed=i)
+        assert task is not None, f"Fase 1 iteració {i}: sampler ha retornat None"
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+        winner = _planted_winner(
+            rng, response_a.model, response_b.model, "gemma-3-4b-it", win_prob_gemma
+        )
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"phase1-{i % 20}",
+        )
+
+    # Snapshot Fase 1: gemma és la millor amb només 3 models al mapa.
+    snapshot = compute_ranking(session, "correccio")
+    assert snapshot["best_model"] == "gemma-3-4b-it"
+    assert set(snapshot["models"]) == set(MODELS)
+    assert snapshot["n_votes_total"] == n_votes_phase1
+
+    # ---- Afegim un 4t model amb resposta a cada prompt ----
+    for prompt, responses in seeded:
+        new_response = Response(
+            prompt=prompt, model=newcomer, text=f"Resposta de {newcomer} a {prompt.code}"
+        )
+        session.add(new_response)
+        responses[newcomer] = new_response
+    session.flush()
+
+    # ---- Fase 2: el nou model guanya al 70% contra qualsevol ----
+    for j in range(n_votes_phase2):
+        i = n_votes_phase1 + j
+        task = select_next_task(session, "correccio", seed=i)
+        assert task is not None, f"Fase 2 iteració {j}: sampler ha retornat None"
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+        winner = _planted_winner(
+            rng, response_a.model, response_b.model, newcomer, win_prob_newcomer
+        )
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"phase2-{j % 20}",
+        )
+
+    # ---- Snapshot final ----
+    final = compute_ranking(session, "correccio")
+    confidence = assess_confidence(session, "correccio", n_bootstrap=200, seed=1714)
+
+    # 1) Ara hi ha 4 models al rànquing, descoberts dinàmicament.
+    assert set(final["models"]) == set(MODELS) | {newcomer}, (
+        f"Esperats 4 models, obtinguts {final['models']}"
+    )
+
+    # 2) El nou model és ara el millor: encara que gemma tingués un cap de sortida,
+    #    500 vots amb un avantatge del 70% són suficients per superar-la.
+    assert final["best_model"] == newcomer, (
+        f"Esperat {newcomer} com a millor, obtingut {final['best_model']}. "
+        f"Skills: {final['bt_skills']}"
+    )
+
+    # 3) gemma segueix superant els altres dos originals (era la segona millor).
+    skills = final["bt_skills"]
+    for other in ["qwen-3.5-9b", "salamandra-7b-instruct"]:
+        assert skills["gemma-3-4b-it"] > skills[other], (
+            f"gemma ha quedat per sota de {other} després de la Fase 2. Skills: {skills}"
+        )
+
+    # 4) Total de vots exacte: no s'han duplicat ni perdut.
+    assert final["n_votes_total"] == n_votes_phase1 + n_votes_phase2
+
+    # 5) El rànquing amb 4 models és estable — assess_confidence no falla amb n>3.
+    assert confidence["is_stable"] is True, (
+        f"Rànquing inestable després d'introduir el nou model. "
+        f"CI=[{confidence['ci_lo']}, {confidence['ci_hi']}]"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — nous prompts a mig camí; el sistema els incorpora sense trencar-se.
+# ---------------------------------------------------------------------------
+
+
+def test_ranking_adapts_when_new_prompts_added_mid_campaign(session):
+    """Fase 1: rànquing amb 3 prompts. Fase 2: afegim 2 prompts més i seguim.
+
+    Escenari real: els lingüistes lliuren més prompts a mig camí. La BD no
+    es buida. Comprovem que:
+        - El sampler descobreix els nous prompts i comença a servir-los.
+        - Quota-balanced els prioritza (comencen a 0 vots).
+        - `compute_ranking` continua funcionant.
+        - `assess_confidence.n_prompts` reflecteix el nombre total de prompts
+          que han rebut vots (5 al final).
+        - El guanyador plantat es manté a través de la transició.
+
+    Configuració:
+        - Categoria: traducció.
+        - Fase 1: 3 prompts × 3 parelles = 9 cel·les.
+          300 vots amb gemma al 60%.
+        - Afegim 2 prompts (arribem a 5 prompts × 3 parelles = 15 cel·les).
+        - Fase 2: 500 vots addicionals; gemma continua guanyant al 60%.
+
+    Comprovacions:
+        - Snapshot Fase 1: 3 prompts amb vots, gemma és la millor.
+        - Post-Fase 2: 5 prompts amb vots, gemma continua sent la millor,
+          els 2 nous prompts han rebut vots reals gràcies al quota-balanced,
+          el rànquing final és estable.
+    """
+    _assert_running_against_test_database(session)
+    _seed_prompts_with_responses(session, "traduccio", n_prompts=3)
+    n_votes_phase1 = 300
+    n_votes_phase2 = 500
+    favored_model = "gemma-3-4b-it"
+    win_prob = 0.60
+
+    # Ni el RNG ens atura. Som i serem
+    rng = np.random.default_rng(seed=1714)
+
+    # ---- Fase 1 amb 3 prompts ----
+    for i in range(n_votes_phase1):
+        task = select_next_task(session, "traduccio", seed=i)
+        assert task is not None, f"Fase 1 iteració {i}: sampler ha retornat None"
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+        winner = _planted_winner(rng, response_a.model, response_b.model, favored_model, win_prob)
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"phase1-prompts-{i % 20}",
+        )
+
+    # Snapshot Fase 1: només 3 prompts al rànquing.
+    snap_ranking = compute_ranking(session, "traduccio")
+    snap_confidence = assess_confidence(session, "traduccio", n_bootstrap=200, seed=1714)
+    assert snap_confidence["n_prompts"] == 3, (
+        f"Esperats 3 prompts amb vots a la Fase 1, obtinguts {snap_confidence['n_prompts']}"
+    )
+    assert snap_ranking["best_model"] == favored_model
+    assert snap_ranking["n_votes_total"] == n_votes_phase1
+
+    # ---- Afegim 2 prompts nous a la categoria (arribem a 5 prompts totals) ----
+    cat_traduccio = _category(session, "traduccio")
+    for i in range(3, 5):
+        prompt = Prompt(
+            version="vtest",
+            code=f"traduccio-scale-{i:02d}",
+            category_id=cat_traduccio.id,
+            text=f"Prompt {i} a traducció (afegit a mig camí)",
+        )
+        session.add(prompt)
+        session.flush()
+        for m in MODELS:
+            session.add(Response(prompt=prompt, model=m, text=f"Resposta de {m} a {prompt.code}"))
+        session.flush()
+
+    # ---- Fase 2 amb 5 prompts ----
+    for j in range(n_votes_phase2):
+        i = n_votes_phase1 + j
+        task = select_next_task(session, "traduccio", seed=i)
+        assert task is not None, f"Fase 2 iteració {j}: sampler ha retornat None"
+
+        response_a = session.get(Response, task["response_a_id"])
+        response_b = session.get(Response, task["response_b_id"])
+        winner = _planted_winner(rng, response_a.model, response_b.model, favored_model, win_prob)
+        _record_vote(
+            session,
+            prompt_id=task["prompt_id"],
+            response_a_id=task["response_a_id"],
+            response_b_id=task["response_b_id"],
+            winner=winner,
+            session_id=f"phase2-prompts-{j % 20}",
+        )
+
+    # ---- Snapshot final ----
+    final_ranking = compute_ranking(session, "traduccio")
+    final_confidence = assess_confidence(session, "traduccio", n_bootstrap=200, seed=1714)
+
+    # 1) Ara tots 5 prompts tenen vots (`n_prompts` compta prompts amb vots decisius).
+    assert final_confidence["n_prompts"] == 5, (
+        f"Esperats 5 prompts amb vots després de la Fase 2, "
+        f"obtinguts {final_confidence['n_prompts']}"
+    )
+
+    # 2) Els prompts NOUS han rebut vots reals: el quota-balanced els ha prioritzat
+    #    perquè començaven a 0 vots quan la resta ja n'acumulava desenes.
+    #    Comprovem-ho llegint els vots per prompt directament de la BD.
+    new_prompt_codes = ["traduccio-scale-03", "traduccio-scale-04"]
+    for code in new_prompt_codes:
+        prompt = session.scalar(select(Prompt).where(Prompt.code == code))
+        assert prompt is not None
+        n_votes_this_prompt = session.scalar(
+            select(Vote).where(Vote.prompt_id == prompt.id).exists().select()
+        )
+        assert n_votes_this_prompt is True, (
+            f"El prompt nou {code} no ha rebut cap vot; quota-balanced no l'ha prioritzat"
+        )
+
+    # 3) gemma continua sent la millor: la transició no altera el guanyador plantat.
+    assert final_ranking["best_model"] == favored_model, (
+        f"Esperat {favored_model}, obtingut {final_ranking['best_model']}. "
+        f"Skills: {final_ranking['bt_skills']}"
+    )
+
+    # 4) Total exacte de vots.
+    assert final_ranking["n_votes_total"] == n_votes_phase1 + n_votes_phase2
+
+    # 5) El rànquing final és estable.
+    assert final_confidence["is_stable"] is True, (
+        f"Rànquing inestable després d'afegir prompts. "
+        f"CI=[{final_confidence['ci_lo']}, {final_confidence['ci_hi']}]"
+    )

--- a/backend/tests/test_ranking.py
+++ b/backend/tests/test_ranking.py
@@ -1,0 +1,211 @@
+"""Tests de `app.ranking.ranking.compute_ranking`.
+
+Inserim vots sintètics a la base de dades de tests i comprovem que la
+funció pública retorna les peces esperades: comptes correctes, BT sensible,
+matriu bruta coherent, detecció de cicles.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.models import Category, Prompt, Response, Vote, Winner
+from app.ranking.ranking import compute_ranking, fit_bt
+
+# ---------------------------------------------------------------------------
+# Helpers per construir l'estat de la base de dades.
+# ---------------------------------------------------------------------------
+
+
+MODELS = ["gemma-3-4b-it", "qwen-3.5-9b", "salamandra-7b-instruct"]
+
+
+def _category(session, code="correccio") -> Category:
+    return session.scalar(select(Category).where(Category.code == code))
+
+
+def _seed_prompts(session, category_code: str, n_prompts: int) -> list[tuple[Prompt, dict]]:
+    """Crea n_prompts dins d'una categoria, cadascun amb una resposta per model."""
+    cat = _category(session, category_code)
+    results = []
+    for i in range(n_prompts):
+        prompt = Prompt(
+            version="vtest",
+            code=f"{category_code}-{i:02d}",
+            category_id=cat.id,
+            text=f"Prompt {i} a {category_code}",
+        )
+        session.add(prompt)
+        session.flush()
+        responses_by_model = {}
+        for m in MODELS:
+            r = Response(prompt=prompt, model=m, text=f"Resposta de {m} a {prompt.code}")
+            session.add(r)
+            responses_by_model[m] = r
+        session.flush()
+        results.append((prompt, responses_by_model))
+    return results
+
+
+def _record_vote(
+    session,
+    prompt: Prompt,
+    response_a: Response,
+    response_b: Response,
+    winner: Winner,
+) -> None:
+    """Insereix un vot."""
+    session.add(
+        Vote(
+            prompt_id=prompt.id,
+            response_a_id=response_a.id,
+            response_b_id=response_b.id,
+            winner=winner,
+        )
+    )
+
+
+def _plant_winner(
+    session,
+    category_code: str,
+    winning_model: str,
+    n_prompts: int = 4,
+    decisive_per_pair_per_prompt: int = 8,
+) -> None:
+    """Insereix vots que fan que `winning_model` sigui clarament el millor.
+
+    Per a cada parella que inclou el guanyador, registra `decisive_per_pair_per_prompt`
+    vots a favor seu i 0 a favor de l'altre. Per a la parella sense el guanyador,
+    reparteix els vots 50/50 perquè no influeixin al rànquing.
+    """
+    prompts = _seed_prompts(session, category_code, n_prompts)
+    for prompt, responses in prompts:
+        for model_a, model_b in [
+            (MODELS[0], MODELS[1]),
+            (MODELS[0], MODELS[2]),
+            (MODELS[1], MODELS[2]),
+        ]:
+            for _ in range(decisive_per_pair_per_prompt):
+                if winning_model in (model_a, model_b):
+                    winner = Winner.a if model_a == winning_model else Winner.b
+                else:
+                    winner = Winner.a  # 50/50 entre no-guanyadors es resol arbitràriament
+                _record_vote(session, prompt, responses[model_a], responses[model_b], winner)
+
+
+# ---------------------------------------------------------------------------
+# fit_bt aïllat (sense base de dades).
+# ---------------------------------------------------------------------------
+
+
+def test_fit_bt_with_empty_votes_returns_zeros():
+    """Sense vots, tots els skills són zero."""
+    skills = fit_bt([], ["a", "b", "c"])
+    assert skills == {"a": 0.0, "b": 0.0, "c": 0.0}
+
+
+def test_fit_bt_recovers_clear_winner():
+    """Si A guanya sempre, A té el skill més alt."""
+    decisive = [("a", "b")] * 50 + [("a", "c")] * 50 + [("b", "c")] * 25 + [("c", "b")] * 25
+    skills = fit_bt(decisive, ["a", "b", "c"])
+    assert skills["a"] > skills["b"]
+    assert skills["a"] > skills["c"]
+    # Sum-to-zero per identificabilitat.
+    assert abs(sum(skills.values())) < 1e-6
+
+
+def test_fit_bt_handles_complete_separation():
+    """A guanya 100% a B; la regularització evita divergència."""
+    decisive = [("a", "b")] * 100
+    skills = fit_bt(decisive, ["a", "b"], alpha=0.01)
+    # Sense regularització, theta_a − theta_b divergiria; amb regularització és finit.
+    assert all(abs(s) < 10.0 for s in skills.values())
+    assert skills["a"] > skills["b"]
+
+
+# ---------------------------------------------------------------------------
+# compute_ranking — escenaris bàsics.
+# ---------------------------------------------------------------------------
+
+
+def test_compute_ranking_empty_category(session):
+    """Sense vots, la sortida és coherent amb valors per defecte."""
+    result = compute_ranking(session, "correccio")
+    assert result["category_code"] == "correccio"
+    assert result["n_votes_total"] == 0
+    assert result["best_model"] is None
+    assert result["bt_skills"] == {}
+    assert result["raw_pairwise"] == []
+    assert result["cycle_detected"] is False
+
+
+def test_compute_ranking_identifies_clear_winner(session):
+    """Si plantem gemma com a guanyadora clara, ha de ser el millor."""
+    _plant_winner(session, "correccio", winning_model="gemma-3-4b-it")
+    result = compute_ranking(session, "correccio")
+    assert result["best_model"] == "gemma-3-4b-it"
+    # Els BT skills sumen zero.
+    assert abs(sum(result["bt_skills"].values())) < 1e-3
+    # gemma té el skill més alt.
+    skills = result["bt_skills"]
+    assert skills["gemma-3-4b-it"] > skills["qwen-3.5-9b"]
+    assert skills["gemma-3-4b-it"] > skills["salamandra-7b-instruct"]
+
+
+def test_compute_ranking_counts_ties_and_neither(session):
+    """Els empats i els 'neither' es reporten per separat i no entren a BT."""
+    prompts = _seed_prompts(session, "traduccio", n_prompts=1)
+    prompt, responses = prompts[0]
+    a, b = responses[MODELS[0]], responses[MODELS[1]]
+    # 3 decisius (A guanya), 2 empats, 1 neither.
+    for _ in range(3):
+        _record_vote(session, prompt, a, b, Winner.a)
+    for _ in range(2):
+        _record_vote(session, prompt, a, b, Winner.tie)
+    _record_vote(session, prompt, a, b, Winner.neither)
+
+    result = compute_ranking(session, "traduccio")
+    assert result["n_votes_total"] == 6
+    assert result["n_votes_decisive"] == 3
+    assert result["n_ties"] == 2
+    assert result["n_neither"] == 1
+
+
+def test_compute_ranking_detects_cycle(session):
+    """Si A>B, B>C, C>A en taxes brutes, marquem cicle."""
+    a_model, b_model, c_model = MODELS  # gemma, qwen, salamandra
+    prompts = _seed_prompts(session, "reformulacio", n_prompts=1)
+    prompt, responses = prompts[0]
+    # A guanya B (clarament).
+    for _ in range(8):
+        _record_vote(session, prompt, responses[a_model], responses[b_model], Winner.a)
+    # B guanya C (clarament).
+    for _ in range(8):
+        _record_vote(session, prompt, responses[b_model], responses[c_model], Winner.a)
+    # C guanya A (clarament).
+    for _ in range(8):
+        _record_vote(session, prompt, responses[c_model], responses[a_model], Winner.a)
+
+    result = compute_ranking(session, "reformulacio")
+    assert result["cycle_detected"] is True
+    assert len(result["cycle_path"]) == 4  # path tancat: [A, B, C, A]
+    assert result["cycle_path"][0] == result["cycle_path"][-1]
+
+
+def test_compute_ranking_isolates_categories(session):
+    """Els vots d'una categoria no contaminen el rànquing d'una altra."""
+    _plant_winner(session, "correccio", winning_model="gemma-3-4b-it", n_prompts=2)
+    _plant_winner(session, "traduccio", winning_model="salamandra-7b-instruct", n_prompts=2)
+
+    r1 = compute_ranking(session, "correccio")
+    r2 = compute_ranking(session, "traduccio")
+    assert r1["best_model"] == "gemma-3-4b-it"
+    assert r2["best_model"] == "salamandra-7b-instruct"
+
+
+def test_compute_ranking_pairwise_keys_are_alphabetical(session):
+    """A la matriu bruta, model_a < model_b alfabèticament."""
+    _plant_winner(session, "correccio", winning_model="gemma-3-4b-it", n_prompts=1)
+    result = compute_ranking(session, "correccio")
+    for stat in result["raw_pairwise"]:
+        assert stat["model_a"] < stat["model_b"]

--- a/backend/tests/test_sampler.py
+++ b/backend/tests/test_sampler.py
@@ -1,0 +1,90 @@
+"""Tests de `app.ranking.sampler.select_next_task`."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from sqlalchemy import select
+
+from app.models import Category, Prompt, Response, Vote, Winner
+from app.ranking.sampler import select_next_task
+
+MODELS = ["gemma-3-4b-it", "qwen-3.5-9b", "salamandra-7b-instruct"]
+
+
+def _category(session, code="correccio"):
+    return session.scalar(select(Category).where(Category.code == code))
+
+
+def _seed_prompts(session, category_code, n_prompts):
+    cat = _category(session, category_code)
+    out = []
+    for i in range(n_prompts):
+        prompt = Prompt(
+            version="vtest",
+            code=f"{category_code}-samp-{i:02d}",
+            category_id=cat.id,
+            text=f"Prompt {i} a {category_code}",
+        )
+        session.add(prompt)
+        session.flush()
+        responses = {}
+        for m in MODELS:
+            r = Response(prompt=prompt, model=m, text=f"Resposta de {m} a {prompt.code}")
+            session.add(r)
+            responses[m] = r
+        session.flush()
+        out.append((prompt, responses))
+    return out
+
+
+def test_select_next_task_returns_none_for_empty_category(session):
+    """Sense prompts, la funció retorna None."""
+    task = select_next_task(session, "correccio")
+    assert task is None
+
+
+def test_select_next_task_returns_well_formed_task(session):
+    """La tasca conté el prompt, dues respostes diferents, sense identificar models."""
+    _seed_prompts(session, "correccio", n_prompts=2)
+    task = select_next_task(session, "correccio", seed=42)
+    assert task is not None
+    assert task["category_code"] == "correccio"
+    assert task["prompt_id"] is not None
+    assert task["response_a_id"] != task["response_b_id"]
+    # Les claus 'model' NO han d'aparèixer — el frontend ha de veure les respostes a cegues.
+    assert "model_a" not in task
+    assert "model_b" not in task
+
+
+def test_select_next_task_balances_cells(session):
+    """Trucant la funció moltes vegades, els recomptes de cel·les són gairebé iguals."""
+    _seed_prompts(session, "traduccio", n_prompts=2)
+
+    # Simulem una campanya: cada cop, llegim la propera tasca i hi enregistrem un vot.
+    counts: Counter = Counter()
+    for i in range(30):
+        task = select_next_task(session, "traduccio", seed=i)
+        assert task is not None
+        # Per comptar la cel·la, recuperem els models de les respostes.
+        ra = session.get(Response, task["response_a_id"])
+        rb = session.get(Response, task["response_b_id"])
+        cell = (task["prompt_id"], *sorted((ra.model, rb.model)))
+        counts[cell] += 1
+        # Guardem el vot perquè la propera crida el vegi.
+        session.add(
+            Vote(
+                prompt_id=task["prompt_id"],
+                response_a_id=task["response_a_id"],
+                response_b_id=task["response_b_id"],
+                winner=Winner.a,
+            )
+        )
+        session.flush()
+
+    # 2 prompts × 3 parelles = 6 cel·les. Amb 30 vots, l'esperat és 5 per cel·la.
+    # Quota-balanced ha de donar comptes propers (diferència ≤ 1).
+    assert len(counts) == 6
+    values = list(counts.values())
+    assert max(values) - min(values) <= 1, f"Cell counts not balanced: {counts}"
+    assert sum(values) == 30

--- a/backend/tests/test_sampler.py
+++ b/backend/tests/test_sampler.py
@@ -88,3 +88,91 @@ def test_select_next_task_balances_cells(session):
     values = list(counts.values())
     assert max(values) - min(values) <= 1, f"Cell counts not balanced: {counts}"
     assert sum(values) == 30
+
+
+def test_select_next_task_excludes_cells_voted_by_session(session):
+    """Si una sessió ja ha votat una cel·la, no se li ha de tornar a oferir."""
+    _seed_prompts(session, "correccio", n_prompts=2)
+    # 2 prompts × 3 parelles = 6 cel·les en total.
+
+    # Una sessió vota 3 cel·les concretes.
+    session_id = "sessio-A"
+    voted_cells: set[tuple[int, str, str]] = set()
+    for _ in range(3):
+        task = select_next_task(session, "correccio", session_id=session_id, seed=_)
+        assert task is not None
+        ra = session.get(Response, task["response_a_id"])
+        rb = session.get(Response, task["response_b_id"])
+        voted_cells.add((task["prompt_id"], *sorted((ra.model, rb.model))))
+        session.add(
+            Vote(
+                prompt_id=task["prompt_id"],
+                response_a_id=task["response_a_id"],
+                response_b_id=task["response_b_id"],
+                winner=Winner.a,
+                session_id=session_id,
+            )
+        )
+        session.flush()
+
+    assert len(voted_cells) == 3  # cap repetició entre els 3 vots
+
+    # Les properes crides amb la MATEIXA sessió no han de retornar cap de les 3 cel·les ja votades.
+    for i in range(5):
+        task = select_next_task(session, "correccio", session_id=session_id, seed=100 + i)
+        assert task is not None
+        ra = session.get(Response, task["response_a_id"])
+        rb = session.get(Response, task["response_b_id"])
+        cell = (task["prompt_id"], *sorted((ra.model, rb.model)))
+        assert cell not in voted_cells, f"Sampler ha tornat a oferir {cell} a {session_id}"
+
+
+def test_select_next_task_returns_none_when_session_completes_category(session):
+    """Quan una sessió ha votat totes les cel·les, la funció retorna None."""
+    _seed_prompts(session, "traduccio", n_prompts=1)
+    # 1 prompt × 3 parelles = 3 cel·les.
+
+    session_id = "sessio-completa"
+    # Votem cada cel·la una vegada des de la mateixa sessió.
+    for i in range(3):
+        task = select_next_task(session, "traduccio", session_id=session_id, seed=i)
+        assert task is not None
+        session.add(
+            Vote(
+                prompt_id=task["prompt_id"],
+                response_a_id=task["response_a_id"],
+                response_b_id=task["response_b_id"],
+                winner=Winner.a,
+                session_id=session_id,
+            )
+        )
+        session.flush()
+
+    # Quarta crida: ja no queden cel·les noves per a aquesta sessió.
+    task = select_next_task(session, "traduccio", session_id=session_id, seed=999)
+    assert task is None
+
+
+def test_select_next_task_different_sessions_are_independent(session):
+    """Una sessió A no afecta el que veu una sessió B."""
+    _seed_prompts(session, "reformulacio", n_prompts=1)
+    # Sessió A vota totes les 3 cel·les.
+    for i in range(3):
+        task = select_next_task(session, "reformulacio", session_id="sessio-A", seed=i)
+        assert task is not None
+        session.add(
+            Vote(
+                prompt_id=task["prompt_id"],
+                response_a_id=task["response_a_id"],
+                response_b_id=task["response_b_id"],
+                winner=Winner.a,
+                session_id="sessio-A",
+            )
+        )
+        session.flush()
+
+    # Sessió A ja no pot votar més.
+    assert select_next_task(session, "reformulacio", session_id="sessio-A", seed=0) is None
+    # Sessió B sí pot votar — encara no ha vist cap cel·la.
+    task_b = select_next_task(session, "reformulacio", session_id="sessio-B", seed=0)
+    assert task_b is not None

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -50,17 +50,17 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
-    { name = "numpy", specifier = ">=1.26" },
+    { name = "numpy", specifier = "==2.5.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "scipy", specifier = ">=1.11" },
+    { name = "scipy", specifier = "==1.18.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "choix", specifier = ">=0.3" },
+    { name = "choix", specifier = "==0.4.1" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.6" },

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -31,14 +31,17 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "numpy" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
+    { name = "scipy" },
     { name = "sqlalchemy" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "choix" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
@@ -47,14 +50,17 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "numpy", specifier = ">=1.26" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "scipy", specifier = ">=1.11" },
     { name = "sqlalchemy", specifier = ">=2.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "choix", specifier = ">=0.3" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.6" },
@@ -67,6 +73,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "choix"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/83/9c9b9aa651e16813ca893b70f4384f2e9c369eafd5922f4ddaf32cde2e9e/choix-0.4.1.tar.gz", hash = "sha256:7c85d13845400932508c45a6a6a3e7a44f637969ffd506e1c7f5db07de1560b4", size = 112425, upload-time = "2025-08-10T20:19:45.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/f1/8ce3fa2fe1649c93ab7e177c3b11b9fd98c66180af3a365cfe7bd0118806/choix-0.4.1-py3-none-any.whl", hash = "sha256:15fe145ffc194dc6b4ba5a44ef24667fa0107578fb5b36723ab0b5e87eeae29f", size = 20575, upload-time = "2025-08-10T20:19:44.255Z" },
 ]
 
 [[package]]
@@ -89,11 +108,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.4"
+version = "3.29.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ee/29c668c50888588c432a702f7c2e8ee8a0c9e5286028d91f170308d6b2e9/filelock-3.29.5.tar.gz", hash = "sha256:6e6034c57a00a020e767f2614a5539863f056de7e7991d6d1473aef7ff73f156", size = 68927, upload-time = "2026-07-03T03:50:31.818Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e3/f1fae3647d170919c2cf2a898e77e7d1a4e5c7cae0aed7bb4bd3f5ebff6f/filelock-3.29.5-py3-none-any.whl", hash = "sha256:8af830889ba3a0ffcefbd6c7d2af8a54012058103771f2e10848222f476a1693", size = 45073, upload-time = "2026-07-03T03:50:30.445Z" },
 ]
 
 [[package]]
@@ -251,6 +270,57 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
 ]
 
 [[package]]
@@ -485,15 +555,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.4.2"
+version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/1a/cbbaf13b730abb0a16b964d984e19f2fe520c21a4dc664051359a3f5a9e7/python_discovery-1.4.2.tar.gz", hash = "sha256:8f3746c4b4968d22afbb97d36e1a0e5b66e6c0f297290f2e95f05b9b8bf18690", size = 70277, upload-time = "2026-06-11T16:10:42.383Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/26/8b004cc36f430345136f6f00fa1aa9ed596c8ed1e8504625fa79522ff39c/python_discovery-1.4.3.tar.gz", hash = "sha256:ad57d7045a862460d4a235986c33f13ed707d3aeb9153fa47eb7dfd0d4673289", size = 70438, upload-time = "2026-07-03T13:21:51.621Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/82/a70006589557f267f15bd384c0642ad49f0d97b690c3a05b166b9dcbad3b/python_discovery-1.4.2-py3-none-any.whl", hash = "sha256:475803f53b7b2ed6e490e27373f9d8340f7d2eebf9acdaf645d7d714c97bb500", size = 33886, upload-time = "2026-06-11T16:10:41.192Z" },
+    { url = "https://files.pythonhosted.org/packages/28/78/9b77ecb4644d1bbea94d29abf78f21c47eca6eb79e9745b702ec0bed2e19/python_discovery-1.4.3-py3-none-any.whl", hash = "sha256:b6e1e4a7d9e3f6948c39746ffe8218225162d738ba39d05ab1d2f6c1cac4878c", size = 33885, upload-time = "2026-07-03T13:21:50.174Z" },
 ]
 
 [[package]]
@@ -574,6 +644,57 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/1a/0725a7cfdc32ff769efb96ee782bec882e16448c5d9e3be947ec4c04ce27/ruff-0.15.18-py3-none-win32.whl", hash = "sha256:02299e6e9fa5b297a3f6d5d10d7bcd655c925b028bb8b9d4588214549c6b9ec4", size = 10901903, upload-time = "2026-06-18T18:25:24.755Z" },
     { url = "https://files.pythonhosted.org/packages/f3/51/805d9f6fb7970505c3504794a5ec350f605361b807fef4dcf214ebd35e72/ruff-0.15.18-py3-none-win_amd64.whl", hash = "sha256:dac80dc8d26b2257dbefabed62f5d255c3937b4ccb122da1fc634794fa3578b3", size = 12041189, upload-time = "2026-06-18T18:25:17.915Z" },
     { url = "https://files.pythonhosted.org/packages/29/4c/67bb45e41609eb4726f1bfeb59e083cf91d14c696d4bd14c234a980be93d/ruff-0.15.18-py3-none-win_arm64.whl", hash = "sha256:b2c9257fcbd4a3e5b977a1904e6facca016bafe2edc17df24db67cfaee03b4e4", size = 11329958, upload-time = "2026-06-18T18:25:43.686Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
 ]
 
 [[package]]

--- a/docs/T7_ranking_design.md
+++ b/docs/T7_ranking_design.md
@@ -1,154 +1,154 @@
-# T7 — Ranking library and pair selection: design proposal
+# T7 — Biblioteca de rànquing i selecció de parelles: proposta de disseny
 
-> Draft. Authored by Gerard Martínez Canelles. Pre-implementation document for [issue #7](https://github.com/Softcatala/arena-cat/issues/7). Branch: `feature/T7_ranking`.
+> Esborrany. Redactat per Gerard Martínez Canelles. Document previ a la implementació de la [issue #7](https://github.com/Softcatala/arena-cat/issues/7). Branch: `feature/T7_ranking`.
 
-This document has **two audiences**:
+Aquest document té **dos públics**:
 
-1. **Reviewers** (Jordi, the team) — sections 1, 6, 7, 8 are the executive summary, the proposed module split, the open questions, and the plan.
-2. **Gerard** (me, learning) — sections 2–5 are a long-form pedagogical walkthrough of the algorithms with worked examples in plain English. Skip if you already know Bradley-Terry / Elo / bootstrap CIs.
+1. **Revisors** (Jordi, l'equip) — les seccions 1, 6, 7 i 8 són el resum executiu, la proposta de separació en mòduls, les preguntes obertes i el pla.
+2. **Gerard** (jo, aprenent) — les seccions 2–5 són un recorregut pedagògic pels algorismes amb exemples pràctics. Salta-les si ja coneixes Bradley-Terry / Elo / bootstrap i intervals de confiança.
 
 ---
 
-## Contents
+## Continguts
 
-1. [Executive summary](#1-executive-summary)
-2. [What questions does the issue actually ask?](#2-what-questions-does-the-issue-actually-ask)
-3. [Crash course: how the ranking algorithms work](#3-crash-course-how-the-ranking-algorithms-work)
-   - [3.1. Raw pairwise win rates](#31-raw-pairwise-win-rates)
+1. [Resum executiu](#1-resum-executiu)
+2. [Què demana realment la issue?](#2-què-demana-realment-la-issue)
+3. [Crash course: com funcionen els algorismes de rànquing](#3-crash-course-com-funcionen-els-algorismes-de-rànquing)
+   - [3.1. Taxes de victòria pairwise brutes](#31-taxes-de-victòria-pairwise-brutes)
    - [3.2. Bradley-Terry](#32-bradley-terry)
    - [3.3. Elo](#33-elo)
    - [3.4. TrueSkill / OpenSkill](#34-trueskill--openskill)
-   - [3.5. Side-by-side comparison](#35-side-by-side-comparison)
-4. [Pair selection: random vs adaptive](#4-pair-selection-random-vs-adaptive)
-5. [How do we know "we have enough votes"?](#5-how-do-we-know-we-have-enough-votes)
-6. [Proposed design](#6-proposed-design)
-7. [Open questions for the team](#7-open-questions-for-the-team)
-8. [Plan ahead](#8-plan-ahead)
+   - [3.5. Comparativa cara a cara](#35-comparativa-cara-a-cara)
+4. [Selecció de tasques (corregint una lectura inicial errònia)](#4-selecció-de-tasques-corregint-una-lectura-inicial-errònia)
+5. [Com sabem que "tenim prou vots"?](#5-com-sabem-que-tenim-prou-vots)
+6. [Disseny proposat](#6-disseny-proposat)
+7. [Preguntes obertes per a l'equip](#7-preguntes-obertes-per-a-lequip)
+8. [Pla de treball](#8-pla-de-treball)
 
 ---
 
-## 1. Executive summary
+## 1. Resum executiu
 
-Issue #7 asks for a library that answers three questions:
+La issue #7 demana una biblioteca que respongui tres preguntes:
 
-1. Which model pair should the next user evaluate?
-2. What is the current ranking?
-3. Have we collected enough votes to trust the ranking?
+1. Quina parella de models ha d'avaluar el proper usuari?
+2. Quin és el rànquing actual?
+3. Hem recollit prou vots per confiar en el rànquing?
 
-After reading the project docs and the issue, my recommendation is:
+Després de llegir la documentació del projecte i la issue, la meva recomanació és:
 
-| Question | Recommendation for Fita 1 (n=3 models) |
+| Pregunta | Recomanació per a la Fita 1 (n=3 models) |
 |---|---|
-| **Q1 — next pair** | **Quota-balanced randomization** over (category, prompt, unordered_pair, side). Pick uniformly among currently underfilled cells. Behind a `TaskSampler` protocol so we can swap in active sampling later. |
-| **Q2 — ranking** | **Raw pairwise stats as the primary public artifact**, with **per-category Bradley-Terry** as a secondary summary. BT fitted with our own ~30-line `scipy.optimize` solver, validated against `choix` in unit tests. |
-| **Q3 — confidence** | **Prompt-cluster bootstrap with fixed labels** from the original fit. Report P(best is best), CI for current best minus strongest competitor, bootstrap rank distribution. |
-| **Stopping rule** | `FixedBudgetRule` default for Fita 1 (we need the full dataset for the public release). `AdaptiveStoppingRule` implemented but not enabled — requires sequential-testing correction before production. |
-| **ρ estimation** | Demoted from stopping logic to **sensitivity analysis** (a slider in the simulador, not a fitted parameter). With 10 prompts × 13 votes, a beta-binomial MLE is unstable. |
-| **Library choice** | Direct `scipy.optimize` BT fit in production; `choix` as a test-time reference for validation only. TrueSkill/OpenSkill not used — they're optimized for online matchmaking, not transparent offline inference with cluster awareness. |
+| **Q1 — propera parella** | **Randomització amb quota equilibrada** sobre (categoria, prompt, parella no ordenada, costat). Tria uniformement entre les cel·les que encara no han arribat al quota. Darrere d'un protocol `TaskSampler` per poder canviar a sampling actiu més endavant. |
+| **Q2 — rànquing** | **Estadístiques pairwise brutes com a artefacte públic principal**, amb **Bradley-Terry per categoria** com a resum secundari. BT ajustat amb un solver propi d'unes ~30 línies amb `scipy.optimize`, validat contra `choix` als unit tests. |
+| **Q3 — confiança** | **Bootstrap de clusters de prompts amb labels fixos** de l'ajust original. Reportem P(el millor és realment el millor), CI del gap entre el millor actual i el competidor més fort, i la distribució de rànquings del bootstrap. |
+| **Regla de parada** | `FixedBudgetRule` per defecte a la Fita 1 (necessitem el dataset complet per al llançament públic). `AdaptiveStoppingRule` implementada però no activada — cal correcció de testing seqüencial abans de posar-la en producció. |
+| **Estimació de ρ** | Degradada de la lògica de parada a **anàlisi de sensibilitat** (un slider al simulador, no un paràmetre ajustat). Amb 10 prompts × 13 vots, un MLE beta-binomial és inestable. |
+| **Elecció de biblioteca** | Ajust de BT directe amb `scipy.optimize` en producció; `choix` només com a referència de validació als tests. TrueSkill/OpenSkill no s'usen — estan optimitzats per a matchmaking online, no per a inferència offline transparent que tingui en compte l'agrupació per prompt. |
 
-**Why raw pairwise stats are primary, not BT:** for n=3 models with ~133 votes per cell, BT's variance reduction over raw pairwise is ~33% in the symmetric case and falls toward 5% when one model dominates. Public communication is also cleaner: "Gemma beat Qwen in 73 of 120 decisive votes (61%, 95% CI [52%, 69%])" requires no model. BT is a useful secondary check and starts paying off in Fita 2+ when n grows.
+**Per què les estadístiques pairwise brutes són l'artefacte principal, no BT:** per a n=3 models amb ~133 vots per cel·la, la reducció de variància de BT sobre pairwise brut és d'un ~33% en el cas simètric i cau fins al 5% quan un model domina. La comunicació pública també és més neta: "Gemma va guanyar Qwen en 73 de 120 vots decisius (61%, IC 95% [52%, 69%])" no requereix cap model. BT és una verificació secundària útil i comença a compensar a la Fita 2+ quan n creix.
 
-**Why quota-balanced randomization, not iid uniform:** iid uniform over 90 (category × prompt × pair) cells with 1,200 votes gives Poisson variance per cell (≈3.6 SD on a mean of 13.3). After complaining about clustering, accepting that level of cell imbalance is self-defeating. Quota-balanced randomization is **not** outcome-adaptive — it depends only on accumulated counts, not on who's winning — so it doesn't trigger the *Leaderboard Illusion* critique.
+**Per què randomització amb quota equilibrada, i no iid uniforme:** iid uniforme sobre 90 cel·les (categoria × prompt × parella) amb 1.200 vots dona una variància de Poisson per cel·la (≈3,6 SD sobre una mitjana de 13,3). Després de queixar-nos de l'agrupació, acceptar aquest nivell de desequilibri entre cel·les és autodestructiu. La randomització amb quota equilibrada **no** és outcome-adaptive — només depèn dels comptadors acumulats, no de qui va guanyant —, així que no dispara la crítica del *Leaderboard Illusion*.
 
-**Why TrueSkill/OpenSkill are wrong fit (precise version):** both libraries are configurable enough to set drift to zero — the strong claim "they always inflate variance" is wrong. The real critique is that they're **designed for online ranking and matchmaking in games**, not for transparent offline inference over a fixed evaluation design. They don't naturally handle prompt clustering, tie/neither semantics, or fixed-quota sampling — the things that actually matter for us.
+**Per què TrueSkill/OpenSkill no encaixen (versió precisa):** ambdues biblioteques són prou configurables per posar el drift a zero — l'afirmació forta "sempre inflen la variància" és falsa. La crítica real és que estan **dissenyades per a rànquing online i matchmaking en jocs**, no per a inferència offline transparent sobre un disseny d'avaluació fix. No gestionen de forma natural l'agrupació per prompt, la semàntica d'empat/cap, ni el sampling amb quotes fixes — les coses que realment ens importen.
 
-The substantive contribution of this task is **not the library choice** — it's the combination of **quota-balanced sampling** (to keep cells balanced) and **prompt-cluster bootstrap with fixed labels** (to get honest uncertainty estimates). The existing simulator's ±8.5% margin is a sensitivity calculation conditional on assumed ρ; under plausible ρ values (0.1–0.5) the per-cell margin is plausibly 13–23% (see [analysis/dimensioning.py](../analysis/dimensioning.py)).
+La contribució substantiva d'aquesta tasca **no és l'elecció de biblioteca** — és la combinació de **sampling amb quota equilibrada** (per mantenir les cel·les equilibrades) i **bootstrap de clusters de prompts amb labels fixos** (per obtenir estimacions honestes d'incertesa). El marge de ±8,5% del simulador actual és un càlcul de sensibilitat condicional a un ρ assumit; amb valors plausibles de ρ (0,1–0,5), el marge per cel·la és plausiblement del 13–23% (vegeu [analysis/dimensioning.py](../analysis/dimensioning.py)).
 
 ---
 
-## 2. What questions does the issue actually ask?
+## 2. Què demana realment la issue?
 
-The full task body from [issue #7](https://github.com/Softcatala/arena-cat/issues/7):
+El text complet de la tasca a la [issue #7](https://github.com/Softcatala/arena-cat/issues/7):
 
-> Implement a library that answers:
-> - Which is the next pair of models to evaluate for the user?
-> - What is the current ranking of the models?
-> - What confidence do we have in the current ranking / have we reached enough evaluations (per category)?
+> Implementa una biblioteca que respongui:
+> - Quina és la propera parella de models que ha d'avaluar l'usuari?
+> - Quin és el rànquing actual dels models?
+> - Quina confiança tenim en el rànquing actual / hem arribat a prou avaluacions (per categoria)?
 >
-> Evaluate using openskill, trueskill or similar. Create simulation scripts.
+> Avaluar utilitzant openskill, trueskill o similar. Crear scripts de simulació.
 
-Reading carefully, this is **two separate concerns wedged into one issue**:
+Si ho llegim amb atenció, veiem que són **dos temes diferents encabits en una sola issue**:
 
-| Concern | Type | Stakes |
+| Tema | Tipus | Impacte |
 |---|---|---|
-| **Pair selection** (Q1) | Online, runs on every API request | Low — wrong choice slightly biases sampling |
-| **Ranking + confidence** (Q2, Q3) | Offline / periodic, runs on the full dataset | High — drives the public ranking and the stopping decision |
+| **Selecció de parelles** (Q1) | Online, s'executa a cada petició API | Baix — una mala tria biaixa lleugerament el sampling |
+| **Rànquing + confiança** (Q2, Q3) | Offline / periòdic, corre sobre el dataset complet | Alt — determina el rànquing públic i la decisió de parada |
 
-These should be **two modules**, not one. They have different testing needs, different update frequencies, and don't have to share a library.
+Han de ser **dos mòduls**, no un. Tenen necessitats de test diferents, freqüències d'actualització diferents, i no cal que comparteixin biblioteca.
 
 ---
 
-## 3. Crash course: how the ranking algorithms work
+## 3. Crash course: com funcionen els algorismes de rànquing
 
-This section is the long pedagogical walkthrough. Skip if you know these algorithms.
+Aquesta secció és el recorregut pedagògic llarg. Salta-la si ja coneixes aquests algorismes.
 
-### 3.1. Raw pairwise win rates
+### 3.1. Taxes de victòria pairwise brutes
 
-**The simplest possible thing.** For every (model_A, model_B, category), count how many times A won and divide by total votes.
+**El més simple possible.** Per a cada (model_A, model_B, categoria), compta quantes vegades ha guanyat A i divideix pel total de vots.
 
-#### Worked example (correcció category)
+#### Exemple pràctic (categoria correcció)
 
-Suppose after some voting we have:
+Suposem que després d'un cert nombre de vots tenim:
 
-| Match-up | Votes for A | Votes for B | Ties |
+| Enfrontament | Vots per A | Vots per B | Empats |
 |---|---|---|---|
 | Qwen vs Salamandra | 73 | 47 | 10 |
 | Qwen vs Gemma | 60 | 60 | 10 |
 | Salamandra vs Gemma | 30 | 90 | 10 |
 
-(Ignoring ties for simplicity: many BT formulations drop them.)
+(Ignorem els empats per simplicitat: moltes formulacions de BT els descarten.)
 
-Raw win rates:
-- Qwen vs Salamandra: 73 / (73 + 47) = **60.8%** for Qwen
-- Qwen vs Gemma: 60 / 120 = **50.0%** (tie at population level)
-- Salamandra vs Gemma: 30 / 120 = **25.0%** for Salamandra (Gemma dominates)
+Taxes de victòria brutes:
+- Qwen vs Salamandra: 73 / (73 + 47) = **60,8%** per Qwen
+- Qwen vs Gemma: 60 / 120 = **50,0%** (empat a nivell poblacional)
+- Salamandra vs Gemma: 30 / 120 = **25,0%** per Salamandra (Gemma domina)
 
-**What's good about this:** transparent, no model assumptions, easy to put a binomial confidence interval on each pair.
+**Què té de bo això:** és transparent, no assumeix cap model, i és fàcil posar-hi un interval de confiança binomial per parella.
 
-**What's bad about this:**
-1. **No global ranking.** You have three independent comparisons; combining them into a single skill score is informal.
-2. **No transitivity sharing.** If Qwen beats Salamandra and Salamandra loses to Gemma, this evidence doesn't update our belief about Qwen vs Gemma.
-3. **No CIs across pairs.** You can put a CI on each pair, but combining them into "the ranking is reliable" requires another step.
+**Què té de dolent:**
+1. **No dona rànquing global.** Tenim tres comparacions independents; combinar-les en una única puntuació de skill és informal.
+2. **No comparteix transitivitat.** Si Qwen guanya Salamandra i Salamandra perd contra Gemma, aquesta evidència no actualitza la nostra creença sobre Qwen vs Gemma.
+3. **No hi ha IC combinats entre parelles.** Pots posar un IC a cada parella, però combinar-los en "el rànquing és fiable" requereix un altre pas.
 
-#### Confidence interval (Wilson, the right one to use)
+#### Interval de confiança (Wilson, el correcte)
 
-For a single pair with `wins` out of `n` votes:
+Per a una única parella amb `wins` sobre `n` vots:
 
 ```python
 p_hat = wins / n
 ci_low, ci_high = wilson_ci(wins, n, confidence=0.95)
 ```
 
-This is what the `simulador/index.html` is computing (approximately). The issue is that **n here is votes, not prompts** — so the CI is too tight when votes within a prompt are correlated. See section 5.
+Això és el que està calculant el `simulador/index.html` (aproximadament). El problema és que **n aquí són vots, no prompts** — així que l'IC és massa estret quan els vots dins d'un prompt estan correlacionats. Vegeu la secció 5.
 
 ---
 
 ### 3.2. Bradley-Terry
 
-**The idea:** assign each model a single number — its **skill** `θ_i`. The probability that model A beats model B is:
+**La idea:** assignem a cada model un únic número — el seu **skill** `θ_i`. La probabilitat que el model A guanyi el model B és:
 
 ```
 P(A beats B) = exp(θ_A) / (exp(θ_A) + exp(θ_B))
             = sigmoid(θ_A - θ_B)
 ```
 
-This is just **logistic regression with model identity as the only feature**. If you've done classification in Python, you know this. If `θ_A = θ_B`, P(A wins) = 0.5. If `θ_A − θ_B = log(2) ≈ 0.69`, A wins 2/3 of the time. If the gap is `log(9) ≈ 2.2`, A wins 90% of the time.
+Això és simplement **regressió logística amb la identitat del model com a única feature**. Si has fet classificació en Python, ja saps com funciona. Si `θ_A = θ_B`, P(A guanya) = 0,5. Si `θ_A − θ_B = log(2) ≈ 0,69`, A guanya 2/3 de les vegades. Si el gap és `log(9) ≈ 2,2`, A guanya el 90% de les vegades.
 
-#### Worked example: fitting BT by hand-wavy intuition
+#### Exemple pràctic: ajustant BT a ull
 
-Using the data from §3.1, BT would assign skills like:
+Amb les dades de la §3.1, BT assignaria skills com:
 
-| Model | Skill `θ` (illustrative) | Interpretation |
+| Model | Skill `θ` (il·lustratiu) | Interpretació |
 |---|---|---|
-| Gemma | +0.6 | strongest |
-| Qwen | +0.2 | middle |
-| Salamandra | −0.8 | weakest |
+| Gemma | +0,6 | el més fort |
+| Qwen | +0,2 | intermedi |
+| Salamandra | −0,8 | el més fluix |
 
-These don't have absolute meaning — only **differences** matter (BT is shift-invariant). What matters is `θ_Gemma − θ_Salamandra = 1.4`, which corresponds to `sigmoid(1.4) ≈ 80%` probability of Gemma winning, matching the 90/120 = 75% observed.
+Aquests valors no tenen significat absolut — només compten les **diferències** (BT és invariant a translacions). El que importa és `θ_Gemma − θ_Salamandra = 1,4`, que correspon a una probabilitat de `sigmoid(1,4) ≈ 80%` que Gemma guanyi, coherent amb el 90/120 = 75% observat.
 
-#### How BT is fitted in practice
+#### Com s'ajusta BT a la pràctica
 
-Maximum likelihood, usually by **iterative algorithms** (MM, Newton, or simply gradient descent in PyTorch). The `choix` library does this for us:
+Màxima verosimilitud, normalment per **algorismes iteratius** (MM, Newton, o simplement gradient descent amb PyTorch). La biblioteca `choix` ens ho fa:
 
 ```python
 import choix
@@ -161,38 +161,38 @@ skills = choix.ilsr_pairwise(n_models, data, alpha=0.01)
 # → array like [0.2, -0.8, 0.6] for [qwen, salamandra, gemma]
 ```
 
-`ilsr_pairwise` = Iterative Luce Spectral Ranking, an efficient solver. `alpha` is a small regularizer to keep things stable when one model has 0 wins or losses.
+`ilsr_pairwise` = Iterative Luce Spectral Ranking, un solver eficient. `alpha` és un regularitzador petit per mantenir l'estabilitat quan un model té 0 victòries o 0 derrotes.
 
-#### The transitivity argument (why BT is "better than raw")
+#### L'argument de la transitivitat (per què BT és "millor que brut")
 
-Imagine we have 100 votes on (Qwen vs Salamandra) and 100 on (Salamandra vs Gemma), but **only 5 on (Qwen vs Gemma)** because the random sampler hasn't hit it much yet.
+Imaginem que tenim 100 vots a (Qwen vs Salamandra) i 100 a (Salamandra vs Gemma), però **només 5 a (Qwen vs Gemma)** perquè el sampler aleatori encara no hi ha caigut gaire.
 
-- **Raw approach:** for (Qwen vs Gemma), we have a CI based on n=5. Very wide.
-- **BT approach:** even with 5 direct votes, the skills `θ_Qwen` and `θ_Gemma` are both *anchored* by the 200 votes that involve Salamandra. The implied (Qwen vs Gemma) probability is much better estimated than 5 votes alone would suggest.
+- **Aproximació bruta:** per a (Qwen vs Gemma), tenim un IC basat en n=5. Molt ampli.
+- **Aproximació BT:** fins i tot amb només 5 vots directes, els skills `θ_Qwen` i `θ_Gemma` estan tots dos *ancorats* pels 200 vots que involucren Salamandra. La probabilitat implícita de (Qwen vs Gemma) queda molt millor estimada que si només tinguéssim aquests 5 vots.
 
-This is the "transitivity savings" the README mentions. The savings grow with `log₂(n)/(n−1)`:
+Això és l'"estalvi de transitivitat" que menciona el README. L'estalvi creix com `log₂(n)/(n−1)`:
 
-| n models | BT reduction factor | Savings |
+| n models | Factor de reducció BT | Estalvi |
 |---|---|---|
-| 2 | 1.00 | 0% |
-| 3 | 0.79 | 21% |
-| 5 | 0.58 | 42% |
-| 10 | 0.37 | 63% |
-| 20 | 0.23 | 77% |
+| 2 | 1,00 | 0% |
+| 3 | 0,79 | 21% |
+| 5 | 0,58 | 42% |
+| 10 | 0,37 | 63% |
+| 20 | 0,23 | 77% |
 
-For **Fita 1 (n=3), BT gives us a 21% reduction**. For Fita 2+ with 10+ models, it becomes much more valuable.
+Per a la **Fita 1 (n=3), BT ens dona una reducció del 21%**. A la Fita 2+ amb 10+ models, l'estalvi es fa molt més valuós.
 
-#### When BT fails
+#### Quan BT falla
 
-BT assumes a **single global axis** of skill. If reality is "Gemma is much better at correcció but Qwen is much better at traducció", a single global BT will smear both. **This is exactly why we fit BT per category, not globally** — see §6.
+BT assumeix un **únic eix global** de skill. Si la realitat és "Gemma és molt millor en correcció però Qwen és molt millor en traducció", un BT global únic ho barrejarà tot. **És precisament per això que ajustem BT per categoria, no globalment** — vegeu §6.
 
 ---
 
 ### 3.3. Elo
 
-**Same model as BT, but fitted online with a simple update rule.**
+**El mateix model que BT, però ajustat online amb una regla d'actualització simple.**
 
-Each model starts at e.g. 1500. After a match where A beats B:
+Cada model comença per exemple a 1500. Després d'una partida on A guanya B:
 
 ```
 expected_A = 1 / (1 + 10^((rating_B - rating_A) / 400))
@@ -200,86 +200,86 @@ rating_A += K * (1 - expected_A)
 rating_B += K * (0 - expected_B)
 ```
 
-Where K is a "learning rate" (typically 16–32 in chess).
+On K és una "taxa d'aprenentatge" (típicament 16–32 als escacs).
 
-**Worked example:**
-- Both at 1500. A beats B.
-- `expected_A = 1 / (1 + 10^0) = 0.5`.
-- `rating_A += K * (1 - 0.5) = 0.5K`. With K=32, A goes to 1516, B drops to 1484.
+**Exemple pràctic:**
+- Tots dos a 1500. A guanya B.
+- `expected_A = 1 / (1 + 10^0) = 0,5`.
+- `rating_A += K * (1 - 0,5) = 0,5K`. Amb K=32, A puja a 1516 i B baixa a 1484.
 
-**Why Elo isn't the right primary tool for us:**
+**Per què Elo no és l'eina principal correcta per a nosaltres:**
 
-1. **Order-dependent.** If you replay the same 200 votes in a different order, you get different final ratings. BT (fitted in batch) is order-independent.
-2. **The K parameter is arbitrary.** Too high → noisy ratings. Too low → ratings don't track the data. There's no principled way to set K for a snapshot evaluation.
-3. **The 400 scaling is a chess convention.** It's the same model as BT under the hood, just with a different parameterization (`log(10) / 400`).
+1. **Depèn de l'ordre.** Si reprodueixes els mateixos 200 vots en un altre ordre, obtens ratings finals diferents. BT (ajustat en batch) és independent de l'ordre.
+2. **El paràmetre K és arbitrari.** Massa alt → ratings sorollosos. Massa baix → els ratings no segueixen les dades. No hi ha una manera principiada de fixar K per a una avaluació d'una instantània.
+3. **El scaling de 400 és una convenció escacs.** El model subjacent és el mateix que BT, només amb una parametrització diferent (`log(10) / 400`).
 
-**Where Elo is useful for us:** as a **cheap online estimate** for pair-selection during voting, computed on the fly without re-fitting a full BT model. But the public ranking should use offline BT.
+**On Elo ens és útil:** com a **estimació online barata** per a la selecció de parelles durant la votació, computable al vol sense refit del model BT complet. Però el rànquing públic hauria d'usar BT offline.
 
-LMSYS Chatbot Arena reports both — see their blog post on the method.
+LMSYS Chatbot Arena reporta tots dos — vegeu el seu post explicant la metodologia.
 
 ---
 
 ### 3.4. TrueSkill / OpenSkill
 
-**Bayesian extension of Elo where each player has a (mean, variance) instead of a single rating.**
+**Extensió bayesiana d'Elo on cada jugador té una (mitjana, variància) en comptes d'un únic rating.**
 
-- TrueSkill: Microsoft, designed for Xbox Live matchmaking.
-- OpenSkill: open-source replacement, similar API.
+- TrueSkill: Microsoft, dissenyat per al matchmaking d'Xbox Live.
+- OpenSkill: reemplaçament open-source, API similar.
 
-The mean is the estimate; the variance shrinks as more matches are observed. A new player starts with high variance ("we don't know"). After matches, the variance decreases.
+La mitjana és l'estimació; la variància es redueix a mesura que s'observen més partides. Un jugador nou comença amb una variància alta ("no ho sabem"). Després de les partides, la variància disminueix.
 
-**The problem for us:** both libraries model **dynamic skill** — they assume a player's true skill drifts over time, and they have parameters like "dynamics factor" or "tau" that govern how much variance is *added back* after each match to prevent the system from getting too confident.
+**El problema per a nosaltres:** ambdues biblioteques modelen **skill dinàmic** — assumeixen que el skill real d'un jugador va derivant amb el temps, i tenen paràmetres com "dynamics factor" o "tau" que governen quanta variància es *torna a afegir* després de cada partida per evitar que el sistema es torni massa confiat.
 
-But our models are **frozen snapshots**. Salamandra 7B's skill at correcció does not drift. Adding dynamics noise is not just unnecessary — it's actively harmful: it inflates variance and gives wider confidence intervals than the data justifies.
+Però els nostres models són **instantànies congelades**. El skill de Salamandra 7B en correcció no deriva. Afegir soroll dinàmic no és només innecessari — és directament perjudicial: infla la variància i dona intervals de confiança més amplis del que les dades justifiquen.
 
-**Conclusion:** TrueSkill/OpenSkill solve a problem we don't have. The issue's suggestion to use them probably reflects which libraries are best-known, not which fits the statistical setting.
+**Conclusió:** TrueSkill/OpenSkill resolen un problema que no tenim. La suggerència de la issue d'usar-los probablement reflecteix quines biblioteques són més conegudes, no quina encaixa millor amb el context estadístic.
 
 ---
 
-### 3.5. Side-by-side comparison
+### 3.5. Comparativa cara a cara
 
-| Property | Raw win rates | Bradley-Terry | Elo | TrueSkill/OpenSkill |
+| Propietat | Win rates brutes | Bradley-Terry | Elo | TrueSkill/OpenSkill |
 |---|---|---|---|---|
-| Global ranking | ❌ | ✅ | ✅ | ✅ |
-| Transitivity sharing | ❌ | ✅ | ✅ | ✅ |
-| Order-independent | ✅ | ✅ | ❌ | ❌ |
-| Online updates | n/a | costly (refit) | cheap | cheap |
-| Models dynamic skill | n/a | ❌ | weakly | ✅ |
-| Easy CI from bootstrap | ✅ | ✅ | trickier | trickier |
-| Fits our setting | partial | **best** | OK for online | overkill |
+| Rànquing global | ❌ | ✅ | ✅ | ✅ |
+| Comparteix transitivitat | ❌ | ✅ | ✅ | ✅ |
+| Independent de l'ordre | ✅ | ✅ | ❌ | ❌ |
+| Actualitzacions online | n/a | costós (refit) | barat | barat |
+| Modela skill dinàmic | n/a | ❌ | dèbilment | ✅ |
+| IC fàcil per bootstrap | ✅ | ✅ | més complicat | més complicat |
+| Encaixa amb el nostre context | parcial | **el millor** | acceptable per online | excessiu |
 
 ---
 
-## 4. Task selection (correcting an earlier misreading)
+## 4. Selecció de tasques (corregint una lectura inicial errònia)
 
-When a user opens the app, the server must pick a **task** — a tuple of `(category, prompt, unordered_model_pair, side_assignment)` — to show them. The unit is not just a model pair: the prompt, the category, and which model is shown on the left vs right all matter.
+Quan un usuari obre l'app, el servidor ha de triar una **tasca** — una tupla de `(categoria, prompt, parella_de_models_no_ordenada, assignació_de_costat)` — per mostrar-l'hi. La unitat no és només una parella de models: el prompt, la categoria i quin model es mostra a l'esquerra vs a la dreta importen tots.
 
-### 4.1. Three candidates
+### 4.1. Tres candidats
 
-| Strategy | How it picks | Pros | Cons |
+| Estratègia | Com tria | Pros | Contres |
 |---|---|---|---|
-| **iid uniform random** | Sample uniformly among all 90 (category × prompt × pair) cells, randomize side | Simple, unbiased | iid creates Poisson cell-count variance — some cells will have 5 votes, others 25, on a budget of 13. Self-defeating given our clustering concern. |
-| **Quota-balanced random** | Sample uniformly among cells currently below the target count, randomize side. Avoid showing the same session the same cell twice. | Same statistical properties as uniform in expectation; cell counts converge to exactly equal. | Slightly more state in the sampler. |
-| **Active sampling (Chiang 2024 rule)** | Probability ∝ `√(σ²/n) − √(σ²/(n+1))` — favors under-evaluated, high-variance pairs | ~30%+ vote savings; what Chiang and Singh both recommend. | Requires running BT estimate at sampling time; needs disclosure. |
+| **Aleatori iid uniforme** | Mostreja uniformement entre les 90 cel·les (categoria × prompt × parella), randomitza el costat | Simple, no esbiaixat | iid crea variància de Poisson en el comptador per cel·la — algunes cel·les tindran 5 vots i altres 25, sobre un pressupost de 13. Autodestructiu donada la nostra preocupació per l'agrupació. |
+| **Aleatori amb quota equilibrada** | Mostreja uniformement entre les cel·les que estan per sota del comptador objectiu, randomitza el costat. Evita mostrar la mateixa cel·la a la mateixa sessió dues vegades. | Les mateixes propietats estadístiques que uniforme en esperança; els comptadors per cel·la convergeixen a exactament iguals. | Una mica més d'estat al sampler. |
+| **Sampling actiu (regla de Chiang 2024)** | Probabilitat ∝ `√(σ²/n) − √(σ²/(n+1))` — afavoreix parelles infra-avaluades i d'alta variància | Estalvi de vots de ~30%+; és el que recomanen tant Chiang com Singh. | Requereix una estimació de BT en el moment del sampling; requereix disclosure. |
 
-### 4.2. The Leaderboard Illusion paper: what it actually says
+### 4.2. El paper del Leaderboard Illusion: què diu realment
 
-I read Singh et al. 2025 carefully. **My earlier framing in this doc was wrong.** The paper's critique is **not** "adaptive sampling is bad". It is:
+He llegit Singh et al. 2025 amb atenció. **El meu enquadrament inicial en aquest document era erroni.** La crítica del paper **no és** "el sampling adaptatiu és dolent". És:
 
-> *"undisclosed sampling rates that systematically over-represent a handful of proprietary providers"* (Section 4.1, paraphrased).
+> *"undisclosed sampling rates that systematically over-represent a handful of proprietary providers"* (Secció 4.1, parafrasejat).
 
-The paper's **Recommendation 4** is **to implement** the active sampling rule from Chiang et al. 2024 (FastChat Section 5, Eq. 9), arguing it "effectively prioritizes under-evaluated and high-variance pairs, aligning sampling with the goal of rapidly reducing uncertainty in rankings". The paper criticizes Chatbot Arena for **claiming** to do this but not actually deploying it.
+La **Recomanació 4** del paper és **implementar** la regla de sampling actiu de Chiang et al. 2024 (FastChat Secció 5, Eq. 9), argumentant que "prioritza efectivament parelles infra-avaluades i d'alta variància, alineant el sampling amb l'objectiu de reduir ràpidament la incertesa en els rànquings". El paper critica Chatbot Arena per **afirmar** que ho fa però no desplegar-ho realment.
 
-So adaptive sampling is fine if: (a) it's based on uncertainty / under-sampling, not on rank closeness for its own sake, and (b) the strategy is publicly disclosed.
+Per tant, el sampling adaptatiu és acceptable si: (a) es basa en incertesa / infra-mostratge, no en proximitat de rànquing per si mateixa, i (b) l'estratègia es fa pública.
 
-### 4.3. Recommendation
+### 4.3. Recomanació
 
-**For Fita 1: quota-balanced randomization, behind a `TaskSampler` protocol.** Reasons:
-- It eliminates the iid-uniform imbalance problem essentially for free.
-- It's not adaptive in any sense and has no disclosure burden.
-- The savings from active sampling at n=3 with a fixed 1,200-vote budget are modest. We're better off spending complexity on bootstrap correctness.
+**Per a la Fita 1: randomització amb quota equilibrada, darrere d'un protocol `TaskSampler`.** Motius:
+- Elimina essencialment de franc el problema de desequilibri iid-uniforme.
+- No és adaptativa en cap sentit i no comporta cap càrrega de disclosure.
+- L'estalvi del sampling actiu amb n=3 i un pressupost fix de 1.200 vots és modest. Val més gastar la complexitat en la correcció del bootstrap.
 
-**For Fita 2+: active sampling becomes attractive.** The Chiang et al. rule is implemented as a second strategy (`UncertaintyDrivenSampler`) and can be turned on via config, with the strategy disclosed on the public ranking page.
+**Per a la Fita 2+: el sampling actiu esdevé atractiu.** La regla de Chiang et al. s'implementa com a segona estratègia (`UncertaintyDrivenSampler`) i es pot activar via config, amb l'estratègia declarada a la pàgina pública del rànquing.
 
 ```python
 # task_sampler.py
@@ -303,48 +303,48 @@ class DiversityWeightedSampler:
     (vegeu §11.1). Els pesos són pre-calculats i no depenen de cap rànquing."""
 ```
 
-**Side randomization is mandatory for all strategies** to avoid position bias. The sampler picks `side_assignment ∈ {A, B}` uniformly per task and does not canonicalize the order in the DB.
+**La randomització del costat és obligatòria per a totes les estratègies** per evitar el biaix de posició. El sampler tria `side_assignment ∈ {A, B}` uniformement per tasca i no canonitza l'ordre a la BD.
 
 ---
 
-## 5. How do we know "we have enough votes"?
+## 5. Com sabem que "tenim prou vots"?
 
-This is the **most underspecified** part of issue #7 and where careful statistics matters most.
+Aquesta és la part **més infra-especificada** de la issue #7, i on l'estadística curosa importa més.
 
-### 5.1. The naive answer (what the simulator does)
+### 5.1. La resposta ingènua (el que fa el simulador)
 
-For each (pair × category) cell, compute a binomial CI on the win rate:
+Per a cada cel·la (parella × categoria), computa un IC binomial sobre la taxa de victòries:
 
 ```python
 margin = z * sqrt(0.25 / n_votes)  # worst case at p=0.5
 ```
 
-For 133 votes → 8.5% margin. **Stop when margin < target.**
+Per a 133 vots → marge del 8,5%. **Paràm quan el marge < objectiu.**
 
-This is wrong when votes within a prompt are correlated, which they are.
+Això és incorrecte quan els vots dins d'un prompt estan correlacionats, que és el nostre cas.
 
-### 5.2. The cluster-aware answer
+### 5.2. La resposta que té en compte l'agrupació
 
-The Kish design effect formula:
+La fórmula del design effect de Kish:
 
 ```
 N_effective = N_raw / (1 + (k − 1) * ρ)
 ```
 
-- `k` = votes per prompt
-- `ρ` = intra-prompt correlation (how much the prompt determines the verdict)
+- `k` = vots per prompt
+- `ρ` = correlació intra-prompt (fins a quin punt el prompt determina el veredicte)
 
-For Fita 1 with ρ ≈ 0.3, the per-cell margin is **plausibly 18%, not 8.5%** — but note this is a sensitivity calculation conditional on assumed ρ, not an empirical truth. With only 10 prompt clusters per category, even with the design effect properly accounted for, the small number of clusters limits the precision of any uncertainty estimate. The asymptotic z = 1.96 approximation is also optimistic at 10 clusters.
+Per a la Fita 1 amb ρ ≈ 0,3, el marge per cel·la és **plausiblement del 18%, no del 8,5%** — però cal notar que això és un càlcul de sensibilitat condicional a un ρ assumit, no una veritat empírica. Amb només 10 clusters de prompt per categoria, fins i tot amb el design effect ben aplicat, el nombre reduït de clusters limita la precisió de qualsevol estimació d'incertesa. L'aproximació asimptòtica z = 1,96 també és optimista amb només 10 clusters.
 
-See the full analysis in [analysis/dimensioning.py](../analysis/dimensioning.py) and the four graphs in `analysis/out/`. The right way to communicate this publicly is **"under plausible ρ ∈ [0.1, 0.5], the margin is 13–23%"**, not "the true margin is 18%".
+Vegeu l'anàlisi completa a [analysis/dimensioning.py](../analysis/dimensioning.py) i les quatre gràfiques a `analysis/out/`. La manera correcta de comunicar-ho públicament és **"sota ρ plausible ∈ [0,1, 0,5], el marge és del 13–23%"**, no "el marge real és 18%".
 
-### 5.3. Operational confidence rule (and a bug fix)
+### 5.3. Regla operativa de confiança (i correcció d'un bug)
 
-**The actual question we want to answer per category:** "Is our currently-best model reliably better than the next-best competitor?"
+**La pregunta real que volem respondre per categoria:** "El model actualment millor és fiablement millor que el següent competidor?"
 
-This is *not* the same as "is the gap between rank 1 and rank 2 large?", because rank 1 and rank 2 can swap across bootstrap replicates. An earlier draft of this doc had a bug here: sorting skills inside each bootstrap replicate forces the gap to be non-negative by construction, which falsely declares stability even when the ranking is unstable.
+Això *no és* el mateix que "és gran el gap entre el rank 1 i el rank 2?", perquè els ranks 1 i 2 poden intercanviar-se entre les rèpliques del bootstrap. Un esborrany anterior d'aquest document tenia un bug aquí: ordenar els skills dins de cada rèplica del bootstrap força que el gap sigui no negatiu per construcció, cosa que declara falsament estabilitat fins i tot quan el rànquing és inestable.
 
-**The fixed-labels cluster bootstrap (correct version):**
+**El bootstrap de clusters amb labels fixos (versió correcta):**
 
 ```python
 # Original: 10 prompts per category (each with many votes)
@@ -369,26 +369,26 @@ p_best_is_best = np.mean([d > 0 for d in deltas])
 ranking_is_stable = ci_lo > 0
 ```
 
-**Why this works:** if the current best is genuinely better, most bootstrap replicates will still show it ahead → `p_best_is_best` close to 1 and `ci_lo > 0`. If the current best is barely ahead and the ranking is fragile, many replicates will show a different model ahead → `delta_b` goes negative in those replicates → `ci_lo < 0` and `p_best_is_best` near 0.5.
+**Per què funciona:** si el millor actual és genuïnament millor, la majoria de rèpliques del bootstrap el continuaran mostrant al davant → `p_best_is_best` proper a 1 i `ci_lo > 0`. Si el millor actual va tot just per davant i el rànquing és fràgil, moltes rèpliques mostraran un altre model al davant → `delta_b` es tornarà negatiu en aquelles rèpliques → `ci_lo < 0` i `p_best_is_best` proper a 0,5.
 
-**Two complementary numbers, not one:**
-- `p_best_is_best` — easy to communicate. "Gemma is the best model in correcció with 87% confidence."
-- `ci_lo, ci_hi` — formal CI on the skill gap. Used in the stopping rule.
+**Dos números complementaris, no un:**
+- `p_best_is_best` — fàcil de comunicar. "Gemma és el millor model en correcció amb un 87% de confiança."
+- `ci_lo, ci_hi` — IC formal sobre el gap de skill. S'utilitza a la regla de parada.
 
-**Important caveats** (worth flagging in any public communication):
-1. With **only 10 prompt clusters**, the cluster bootstrap is more honest than iid bootstrap, but it is not magic — cluster bootstrap with very few clusters has known small-sample issues.
-2. The bootstrap accounts for **prompt-level dependence** only. **Session-level dependence** (one volunteer casting many votes) is a separate source of correlation we should report on but not fold into the bootstrap until v2 (when we have users).
-3. The rule "**Pr(current best is best) > 95%**" is *not* the same as "**we have detected a statistically significant gap**" — be careful in public framing.
+**Advertiments importants** (val la pena marcar-los en qualsevol comunicació pública):
+1. Amb **només 10 clusters de prompt**, el bootstrap de clusters és més honest que el bootstrap iid, però no és màgia — el bootstrap de clusters amb pocs clusters té problemes coneguts de mostra petita.
+2. El bootstrap només té en compte la **dependència a nivell de prompt**. La **dependència a nivell de sessió** (un voluntari que fa molts vots) és una font de correlació separada de la qual hauríem d'informar, però sense ficar-la al bootstrap fins a v2 (quan tinguem usuaris).
+3. La regla "**Pr(el millor actual és el millor) > 95%**" *no és* el mateix que "**hem detectat un gap estadísticament significatiu**" — cal anar amb compte a la comunicació pública.
 
-### 5.4. ρ is not in the public confidence story
+### 5.4. ρ no forma part del relat públic de confiança
 
-`ρ` stays as a **sensitivity slider** in the simulador and an internal diagnostic. We do **not** fit a single ρ from the data and publish a confidence claim that depends on it — with 10 prompts × 13 votes, the beta-binomial MLE is unstable and a single ρ would hide several distinct sources of dependence (prompt difficulty, model-prompt interaction, session effects, position bias, category ambiguity). Treat ρ as a "what-if" tool, not as a parameter we estimate.
+`ρ` es queda com a **slider de sensibilitat** al simulador i com a diagnòstic intern. **No** ajustem un ρ únic a partir de les dades ni publiquem una afirmació de confiança que en depengui — amb 10 prompts × 13 vots, l'MLE beta-binomial és inestable i un ρ únic amagaria diverses fonts diferents de dependència (dificultat del prompt, interacció model-prompt, efectes de sessió, biaix de posició, ambigüitat de categoria). Tracta ρ com una eina de "què passaria si...", no com un paràmetre a estimar.
 
 ---
 
-## 6. Proposed design
+## 6. Disseny proposat
 
-### 6.1. Module split
+### 6.1. Separació en mòduls
 
 ```
 backend/app/ranking/
@@ -399,9 +399,9 @@ backend/app/ranking/
     types.py            # dataclasses, kept free of SQLAlchemy
 ```
 
-**Design constraint:** the core types and functions consume plain dataclasses or dataframes, not SQLAlchemy ORM rows. The API layer is responsible for translating ORM rows into core types. This keeps the math testable in isolation and avoids coupling ranking logic to the DB session.
+**Restricció de disseny:** els tipus i funcions del nucli consumeixen dataclasses o dataframes plans, no files ORM de SQLAlchemy. La capa API és responsable de traduir les files ORM als tipus del nucli. Això manté la matemàtica testable de forma aïllada i evita acoblar la lògica de rànquing a la sessió de BD.
 
-Plus simulation scripts under `scripts/`:
+Més els scripts de simulació sota `scripts/`:
 
 ```
 scripts/
@@ -409,11 +409,11 @@ scripts/
     benchmark_methods.py    # Compare BT vs raw win rates on real-ish data
 ```
 
-### 6.2. Public API (sketch)
+### 6.2. API pública (esbós)
 
-#### Task sampler — Strategy pattern
+#### Task sampler — patró Strategy
 
-To avoid technical debt later, we expose a `TaskSampler` protocol with three interchangeable implementations. The microservice picks one at startup via configuration. We start with `QuotaBalancedSampler` for Fita 1 and can switch to weighted or active sampling later without API changes.
+Per evitar deute tècnic més endavant, exposem un protocol `TaskSampler` amb tres implementacions intercanviables. El microservei en tria una a l'arrencada via configuració. Comencem amb `QuotaBalancedSampler` per a la Fita 1 i podem canviar a weighted o active sampling més endavant sense canvis d'API.
 
 ```python
 # task_sampler.py
@@ -494,7 +494,7 @@ class AdaptiveStoppingRule:
     def __init__(self, min_votes_per_cell: int = 50, alpha: float = 0.05): ...
 ```
 
-### 6.3. Dependencies to add
+### 6.3. Dependències a afegir
 
 ```toml
 [project.dependencies]
@@ -507,15 +507,15 @@ dev = [
 ]
 ```
 
-**Why scipy in production, choix only in tests.** The BT log-likelihood is ~30 lines in pure scipy with a sum-to-zero constraint and an explicit L2 regularization parameter `alpha` whose meaning is unambiguous. `choix` is excellent but its `alpha` semantics are algorithm-dependent (pairwise pseudo-counts in MM solvers, L2/Gaussian in scipy-based solvers), which makes it slightly less transparent for our use case. We use it in unit tests to validate our scipy fit against an independent implementation on planted data.
+**Per què scipy en producció i choix només als tests.** La log-versemblança de BT són ~30 línies en scipy pur amb una restricció sum-to-zero i un paràmetre L2 explícit `alpha` amb un significat inequívoc. `choix` és excel·lent però la semàntica del seu `alpha` depèn de l'algorisme (pseudo-comptadors pairwise als solvers MM, L2/gaussià als basats en scipy), cosa que el fa lleugerament menys transparent per al nostre cas d'ús. L'usem als unit tests per validar el nostre ajust scipy contra una implementació independent sobre dades sintètiques amb skills coneguts.
 
-**Complete separation guard.** If a model wins 0 or all decisive comparisons against another model in some category (possible with sparse data), the plain BT MLE diverges. The L2 regularization handles this gracefully; we test for it explicitly.
+**Protecció contra separació completa.** Si un model guanya 0 o totes les comparacions decisives contra un altre model en alguna categoria (possible amb dades escasses), el MLE de BT sense regularització divergeix. La regularització L2 ho gestiona amb gràcia; ho testem explícitament.
 
-No frontend changes. No DB changes (the existing schema in `models.py` is sufficient).
+Cap canvi al frontend. Cap canvi a la BD (l'esquema actual a `models.py` és suficient).
 
-### 6.4. TDD plan
+### 6.4. Pla de TDD
 
-Following the project convention (`AGENTS.md`), tests come first. In English identifiers, Catalan docstrings:
+Seguint la convenció del projecte (`AGENTS.md`), els tests van primer. Identificadors en anglès, docstrings en català:
 
 ```python
 # tests/test_pair_selector.py
@@ -543,219 +543,219 @@ def test_unstable_ranking_with_coin_flip_data():
     """Si totes les parelles són 50/50, is_ranking_stable=False."""
 ```
 
-### 6.5. Why this design beats the literal issue #7
+### 6.5. Per què aquest disseny supera la lectura literal de la issue #7
 
-| What issue #7 says | What we propose | Why |
+| Què diu la issue #7 | Què proposem | Per què |
 |---|---|---|
-| "Use openskill / trueskill" | Direct scipy BT fit + choix-as-test-reference | openskill / trueskill are tuned for online matchmaking, not transparent offline inference |
-| Single library | Three modules (sampler, ranking, confidence) | Different stakes, different test patterns. Sampler doesn't depend on BT; BT doesn't depend on bootstrap. |
-| "Confidence in the ranking" | **Fixed-label** cluster bootstrap on `θ_best − max(θ_others)`, plus P(best is best) | Earlier "sort-and-take-top-2-gap" version had a sign bug; this one allows negative deltas and correctly reflects rank instability |
-| Implicit: iid uniform sampling | Quota-balanced randomization | iid creates Poisson cell imbalance on small budgets; quota-balanced doesn't trigger Leaderboard Illusion either way |
-| Simulation scripts | Plus benchmark of BT vs raw + adversarial cases | We show empirically that BT savings are ~33% in the symmetric case at n=3, falling toward 5% when one model dominates |
+| "Utilitzar openskill / trueskill" | Ajust directe amb scipy BT + choix com a referència de test | openskill / trueskill estan afinats per matchmaking online, no per a inferència offline transparent |
+| Una sola biblioteca | Tres mòduls (sampler, ranking, confidence) | Impactes diferents, patrons de test diferents. El sampler no depèn de BT; BT no depèn del bootstrap. |
+| "Confiança en el rànquing" | Bootstrap de clusters **amb labels fixos** sobre `θ_best − max(θ_others)`, més P(el millor és el millor) | La versió anterior de "ordenar i agafar el gap del top-2" tenia un bug de signe; aquesta versió permet deltes negatius i reflecteix correctament la inestabilitat del rànquing |
+| Implícit: sampling iid uniforme | Randomització amb quota equilibrada | iid crea desequilibri de Poisson a les cel·les amb pressupostos petits; el quota-balanced no dispara el Leaderboard Illusion tampoc |
+| Scripts de simulació | Més benchmark BT vs raw + casos adversarials | Mostrem empíricament que l'estalvi de BT és del ~33% en el cas simètric a n=3, caient fins al ~5% quan un model domina |
 
-### 6.6. Other product / methodology considerations
+### 6.6. Altres consideracions de producte / metodologia
 
-| Concern | Handling |
+| Preocupació | Com es gestiona |
 |---|---|
-| **Position bias (A vs B side)** | Side randomized per task by the sampler. Audit metric: per-model A-vs-B win-rate difference, reported in `confidence.py` outputs. |
-| **Session-level clustering** | `session_id` tracked, reported as a concentration metric (max votes per session, Herfindahl index). Not folded into the bootstrap until v2 introduces users. |
-| **Tie vs neither** | Reported as **separate** rates. For BT input: drop both. For raw stats: half-credit for tie, exclude neither (not half-credit, because neither means "neither is acceptable" not "they're equivalent"). |
-| **Category code immutability** | `cultura → reformulacio` (commit `439463a`) is a real rename. Category **codes** must be immutable for longitudinal analysis; display names can change. Flag this convention in `AGENTS.md` and our module README. |
-| **Model versioning in public outputs** | The public ranking exports `model + inference_metadata.{seed, temperature, top_p, quantization, model_version}` so the result can't be retroactively attributed to a different checkpoint. The data is already in the schema (`Response.inference_metadata`). |
-| **Cycle detection** | With n=3 raw pairwise can produce a cycle (A>B>C>A) that BT smooths away. Report when this happens — it's a meaningful signal about heterogeneity, not a bug. |
+| **Biaix de posició (costat A vs B)** | El sampler randomitza el costat per tasca. Mètrica d'auditoria: diferència de win-rate A vs B per model, reportada a les sortides de `confidence.py`. |
+| **Agrupació a nivell de sessió** | `session_id` es tracta i es reporta com a mètrica de concentració (màxim de vots per sessió, índex de Herfindahl). No s'incorpora al bootstrap fins que v2 introdueixi usuaris. |
+| **Empat vs cap** | Es reporten com a taxes **separades**. Per a l'entrada de BT: es descarten totes dues. Per a les estadístiques brutes: mig punt per l'empat, s'exclou "cap" (no mig punt, perquè "cap" vol dir "cap dels dos és acceptable" i no "són equivalents"). |
+| **Immutabilitat dels codis de categoria** | `cultura → reformulacio` (commit `439463a`) és un rename real. Els **codis** de categoria han de ser immutables per a l'anàlisi longitudinal; els noms per mostrar poden canviar. Marquem aquesta convenció a `AGENTS.md` i al README del mòdul. |
+| **Versionatge de model a les sortides públiques** | El rànquing públic exporta `model + inference_metadata.{seed, temperature, top_p, quantization, model_version}` perquè el resultat no es pugui atribuir retroactivament a un checkpoint diferent. Les dades ja hi són a l'esquema (`Response.inference_metadata`). |
+| **Detecció de cicles** | Amb n=3 el pairwise brut pot produir un cicle (A>B>C>A) que BT suavitza. Reportem-lo quan passi — és un senyal significatiu sobre l'heterogeneïtat, no un bug. |
 
 ---
 
-## 7. Open questions for the team
+## 7. Preguntes obertes per a l'equip
 
-Before implementation starts, I'd like to confirm:
+Abans que comenci la implementació, m'agradaria confirmar:
 
-**Q1.** Do we want **per-category** rankings, **global**, or **both**? The README implies per-category but doesn't say it explicitly.
-> **My recommendation:** per-category is the product question. Global is a nice-to-have.
+**Q1.** Volem rànquings **per categoria**, **globals**, o **tots dos**? El README suggereix per categoria però no ho diu explícitament.
+> **La meva recomanació:** per categoria és la pregunta de producte. El global és un "estaria bé tenir-ho".
 
-**Q2.** Is the team OK with **random uniform** pair selection, or do you want adaptive? I argue strongly for random — see §4.
-> **My recommendation:** implement **both** behind a `PairSelector` protocol (§6.2) and ship `UniformRandomSelector` as the Fita 1 default. This way we can switch to adaptive later via config without a new PR. Adaptive will require public disclosure to avoid the Leaderboard Illusion critique (see `leaderboard_illusion_response.md`).
+**Q2.** L'equip està d'acord amb la selecció de parella **aleatòria uniforme**, o preferiu adaptativa? Argumento fortament per l'aleatòria — vegeu §4.
+> **La meva recomanació:** implementar **totes dues** darrere d'un protocol `PairSelector` (§6.2) i llençar `UniformRandomSelector` com a default a la Fita 1. Així podem canviar a adaptativa més endavant via config sense un nou PR. L'adaptativa requerirà disclosure pública per evitar la crítica del Leaderboard Illusion (vegeu `leaderboard_illusion_response.md`).
 
-**Q3.** How do we handle **ties and "neither"** votes? Three options:
-- (a) Drop them entirely.
-- (b) Count a tie as half a win for each side.
-- (c) Model ties explicitly with a "tie threshold" parameter (Rao-Kupper extension of BT).
-> **My recommendation:** (b) for raw win rates, (a) for BT (it's the standard).
+**Q3.** Com gestionem els **empats i els vots de "cap"**? Tres opcions:
+- (a) Descartar-los del tot.
+- (b) Comptar un empat com a mig punt per a cada costat.
+- (c) Modelar els empats explícitament amb un paràmetre de "llindar d'empat" (extensió Rao-Kupper de BT).
+> **La meva recomanació:** (b) per a les taxes brutes, (a) per a BT (és el que és estàndard).
 
-**Q4.** What's the **stopping criterion** for Fita 1? Hit the 1,200-vote target regardless, or stop early per-category if the ranking stabilizes?
-> **My recommendation:** implement **both** behind a `StoppingRule` protocol (§6.2) and ship `FixedBudgetRule` as the Fita 1 default — we want the full dataset for the public release (`projecte.md` §6.2). `AdaptiveStoppingRule` is wired up for later use, but requires sequential-testing corrections (alpha-spending) before production use to avoid the "peeking" bias.
+**Q4.** Quin és el **criteri de parada** per a la Fita 1? Arribar als 1.200 vots objectiu sí o sí, o parar aviat per categoria si el rànquing s'estabilitza?
+> **La meva recomanació:** implementar **totes dues** darrere d'un protocol `StoppingRule` (§6.2) i llençar `FixedBudgetRule` com a default de la Fita 1 — volem el dataset complet per al llançament públic (`projecte.md` §6.2). `AdaptiveStoppingRule` queda cablejada per a ús futur, però requereix correccions de testing seqüencial (alpha-spending) abans de posar-la en producció per evitar el biaix de "peeking".
 
-**Q5.** The "Leaderboard Illusion" concern in the bibliography — Arena Cat's response to each critique is documented in [`leaderboard_illusion_response.md`](leaderboard_illusion_response.md).
+**Q5.** La preocupació del "Leaderboard Illusion" a la bibliografia — la resposta d'Arena Cat a cada crítica està documentada a [`leaderboard_illusion_response.md`](leaderboard_illusion_response.md).
 
 ---
 
-## 8. Plan ahead
+## 8. Pla de treball
 
-### Phase 0 — Alignment (this doc + review)
-- ✅ Branch `feature/T7_ranking` created.
-- ⏳ Post this doc as a comment on issue #7 and request feedback from Jordi.
-- ⏳ Resolve the 5 open questions in §7.
+### Fase 0 — Alineació (aquest document + revisió)
+- ✅ Branch `feature/T7_ranking` creada.
+- ⏳ Publicar aquest document com a comentari a la issue #7 i demanar feedback al Jordi.
+- ⏳ Resoldre les 5 preguntes obertes de §7.
 
-### Phase 1 — Synthetic validation (no production code yet)
-- Write `scripts/simulate_ranking.py` that generates synthetic votes from known model skills with a given ρ.
-- Confirm that the cluster bootstrap recovers the right CI width.
-- Reproduce the 21% BT savings empirically for n=3 models.
-- This is the work that lets us say "this design works" *before* anyone uses it.
+### Fase 1 — Validació sintètica (encara sense codi de producció)
+- Escriure `scripts/simulate_ranking.py` que generi vots sintètics a partir de skills coneguts amb un ρ donat.
+- Confirmar que el bootstrap de clusters recupera l'amplada d'IC correcta.
+- Reproduir empíricament l'estalvi del 21% de BT per a n=3 models.
+- Aquesta és la feina que ens permetrà dir "aquest disseny funciona" *abans* que ningú l'utilitzi.
 
-### Phase 2 — Implementation (TDD, small PRs)
-- PR 1: `pair_selector.py` + tests. Trivial; opens the door.
-- PR 2: `ranking.py` (BT per category + raw stats) + tests.
-- PR 3: `confidence.py` (cluster bootstrap, ρ estimation, stopping rule) + tests.
-- PR 4: Integration test that wires all three modules together on seeded data.
+### Fase 2 — Implementació (TDD, PRs petits)
+- PR 1: `pair_selector.py` + tests. Trivial; obre la porta.
+- PR 2: `ranking.py` (BT per categoria + estadístiques brutes) + tests.
+- PR 3: `confidence.py` (bootstrap de clusters, estimació de ρ, regla de parada) + tests.
+- PR 4: Test d'integració que connecta els tres mòduls sobre dades amb seed.
 
-### Phase 3 — Integration with the microservice (issue #6)
-- Once issue #6's FastAPI service exists, expose three endpoints:
-  - `GET /api/task` calls `pair_selector.select_next_task`.
-  - `GET /api/stats` calls `ranking.compute_rankings` + `confidence.assess_confidence`.
-  - The `POST /api/vote` already exists per `pla_detallat.md`; just writes to the DB.
-- This phase is **out of scope for this task** but the API surface is designed so it slots in cleanly.
+### Fase 3 — Integració amb el microservei (issue #6)
+- Un cop existeixi el servei FastAPI de la issue #6, exposem tres endpoints:
+  - `GET /api/task` crida `pair_selector.select_next_task`.
+  - `GET /api/stats` crida `ranking.compute_rankings` + `confidence.assess_confidence`.
+  - El `POST /api/vote` ja existeix segons `pla_detallat.md`; només escriu a la BD.
+- Aquesta fase és **fora d'abast d'aquesta tasca** però l'API està dissenyada per encaixar-hi netament.
 
-### Phase 4 — Documentation
-- Update `docs/db_schema.md` if any new tables/views are needed (currently I think we can compute everything from `votes` + `responses` + `prompts` + `categories`).
-- Add a short `backend/app/ranking/README.md` explaining the three modules.
+### Fase 4 — Documentació
+- Actualitzar `docs/db_schema.md` si calen taules/views noves (ara mateix crec que podem calcular-ho tot a partir de `votes` + `responses` + `prompts` + `categories`).
+- Afegir un `backend/app/ranking/README.md` curt que expliqui els tres mòduls.
 
-### Estimated effort
+### Estimació d'esforç
 
-| Phase | Hours |
+| Fase | Hores |
 |---|---|
-| Phase 0 (alignment) | ~3 |
-| Phase 1 (synthetic validation) | ~8 |
-| Phase 2 (implementation, 4 PRs) | ~20 |
-| Phase 3 (FastAPI wiring) | depends on #6 |
-| Phase 4 (docs) | ~2 |
-| **Total (excluding #6 dependency)** | **~33 hours** |
+| Fase 0 (alineació) | ~3 |
+| Fase 1 (validació sintètica) | ~8 |
+| Fase 2 (implementació, 4 PRs) | ~20 |
+| Fase 3 (cablejat amb FastAPI) | depèn de #6 |
+| Fase 4 (docs) | ~2 |
+| **Total (excloent-ne la dependència de #6)** | **~33 hores** |
 
-This fits the ~120-hour Fita 1 budget called out in [README.md](../README.md#fita-1-prova-de-concepte).
+Cap dins el pressupost de ~120 hores de la Fita 1 marcat al [README.md](../README.md#fita-1-prova-de-concepte).
 
 ---
 
-## 11. Updates after rebase onto main (2026-06-27)
+## 11. Actualitzacions després del rebase sobre main (2026-06-27)
 
-The branch was rebased onto `origin/main` and the issue / PR list was re-checked. Two commits had landed on main since the doc was written; neither affects this design directly:
+La branch s'ha rebasat sobre `origin/main` i s'ha tornat a revisar la llista d'issues / PRs. Dos commits havien aterrat a main des que es va redactar el document; cap dels dos afecta aquest disseny directament:
 
-- `00c5228` — disabled reasoning in `scripts/inferencia.py`, added per-model inference time tracking.
-- `39bd981` — removed the `contributors-readme-action` workflow.
+- `00c5228` — desactivat el reasoning a `scripts/inferencia.py`, afegit el tracking del temps d'inferència per model.
+- `39bd981` — eliminat el workflow `contributors-readme-action`.
 
-Three open items on the repo deserve a mention because they touch our scope.
+Tres punts oberts al repositori mereixen menció perquè toquen el nostre abast.
 
-### 11.1. PR #18 — "Càlcul de diversitat dels prompts" (open, Jordi)
+### 11.1. PR #18 — "Càlcul de diversitat dels prompts" (obert, Jordi)
 
-Adds two scripts:
-- `scripts/metriques.py` — computes pairwise distances between the three models' outputs on the same prompt, using **chrF** (character n-gram similarity) and **Levenshtein**, both normalized to a 0–1 distance.
-- `scripts/analitza_inferencies.py` — produces a `results.txt` that ranks the 30 prompts by how *discriminating* they are (prompts where the three models produce more divergent outputs rank higher).
+Afegeix dos scripts:
+- `scripts/metriques.py` — computa les distàncies pairwise entre les sortides dels tres models sobre el mateix prompt, usant **chrF** (similitud d'n-grames de caràcters) i **Levenshtein**, tots dos normalitzats a una distància 0–1.
+- `scripts/analitza_inferencies.py` — produeix un `results.txt` que ordena els 30 prompts per com de *discriminatoris* són (els prompts on els tres models produeixen sortides més divergents pugen més).
 
-**Why this matters for our pair selector.** If two models produce nearly identical outputs for a given prompt, a human evaluator cannot meaningfully prefer one. The vote becomes near-50/50 noise, which:
-- Wastes human time.
-- Inflates the intra-prompt correlation `ρ` we worried about in §5, because the random noise dominates the within-prompt signal.
+**Per què això importa per al nostre selector de parelles.** Si dos models produeixen sortides gairebé idèntiques per a un prompt determinat, un avaluador humà no pot preferir-ne un de manera significativa. El vot es converteix en soroll gairebé 50/50, cosa que:
+- Malbarata temps humà.
+- Infla la correlació intra-prompt `ρ` que ens preocupava a §5, perquè el soroll aleatori domina el senyal dins del prompt.
 
-This is genuinely useful **prior information** that's computable offline, before any vote is collected.
+Això és genuïnament **informació prèvia útil** i computable offline, abans que es reculli cap vot.
 
-**Two ways to use it (both compatible with §4's "no Leaderboard Illusion" stance):**
+**Dues maneres d'aprofitar-ho (totes dues compatibles amb la postura de "no Leaderboard Illusion" de §4):**
 
-| Approach | What it does | Trade-off |
+| Aproximació | Què fa | Compromís |
 |---|---|---|
-| **A — Filter** | Drop prompts where pairwise output similarity is above a threshold (e.g., `chrF_d < 0.15`) | Cleaner stats; smaller dataset |
-| **B — Weighted random sampling** | Down-weight (but don't exclude) non-discriminating prompts in the random sampler | Keeps all prompts; biases toward informative ones |
+| **A — Filtre** | Descartar els prompts on la similitud pairwise de sortides superi un llindar (per exemple, `chrF_d < 0,15`) | Estadístiques més netes; dataset més petit |
+| **B — Random sampling ponderat** | Ponderar cap avall (però no excloure) els prompts poc discriminatoris al sampler aleatori | Manté tots els prompts; esbiaixa cap als informatius |
 
-**Important — why this is NOT adaptive sampling in the harmful sense.** The diversity weights are:
-- Computed **once** from the pre-generated model outputs.
-- **Frozen** before voting starts.
-- **Independent** of the current ranking estimate.
+**Important — per què això NO és sampling adaptatiu en el sentit perjudicial.** Els pesos de diversitat són:
+- Computats **una sola vegada** a partir de les sortides pre-generades dels models.
+- **Congelats** abans que comenci la votació.
+- **Independents** de l'estimació actual del rànquing.
 
-The Leaderboard Illusion critique targets samplers that bias toward currently-close-in-ranking pairs *based on accumulating vote data*. A frozen prior on prompt informativeness doesn't do that — it's the same logic as power analysis for test selection, which is standard practice.
+La crítica del Leaderboard Illusion apunta a samplers que esbiaixen cap a parelles amb rànquings actualment propers *basant-se en dades de vot acumulades*. Un prior congelat sobre la informativitat dels prompts no fa això — és la mateixa lògica que l'anàlisi de potència per a la selecció de tests, que és pràctica estàndard.
 
-**My recommendation:** Once PR #18 merges, use `DiversityWeightedSampler` (the third strategy in §6.2) as an optional config — quota-balanced randomization, but with prompts within each (category, pair) cell sampled in proportion to their pre-computed diversity scores. Implementation in `task_sampler.py`:
+**La meva recomanació:** Un cop el PR #18 estigui merged, usar `DiversityWeightedSampler` (la tercera estratègia de §6.2) com a config opcional — randomització amb quota equilibrada, però amb els prompts dins de cada cel·la (categoria, parella) mostrejats en proporció als seus scores de diversitat pre-calculats. Implementació a `task_sampler.py`:
 
 ```python
 # Per (category × pair) cell, pick prompts according to diversity-weighted quota.
 # Weights are computed once at startup from PR #18's output, frozen for the campaign.
 ```
 
-If PR #18 doesn't merge, fall back to plain `QuotaBalancedSampler` (uniform among under-quota cells). No code change required.
+Si el PR #18 no es fa merge, tornem al `QuotaBalancedSampler` a seques (uniforme entre les cel·les infra-quota). Cap canvi de codi.
 
-**Open question for the team:** is Approach B acceptable, or do you want strict uniform for maximum transparency? My weak preference is B because it makes better use of the volunteer budget.
+**Pregunta oberta per a l'equip:** és acceptable l'aproximació B, o preferiu uniforme estricte per màxima transparència? La meva preferència feble és B perquè aprofita millor el pressupost de voluntaris.
 
-### 11.2. Issue #6 (microservice) is assigned to Isaac Nicolas
+### 11.2. La issue #6 (microservei) està assignada a Isaac Nicolas
 
-The downstream consumer of our library. Worth coordinating once we land Phase 1 so the API surface is what he needs. **Not verified yet:** whether Isaac has started, whether a draft API contract exists.
+És el consumidor downstream de la nostra biblioteca. Val la pena coordinar-se un cop hàgim aterrat la Fase 1 perquè l'API sigui la que ell necessita. **Encara no verificat:** si l'Isaac ha començat, si existeix un esborrany de contracte d'API.
 
-**Action:** ping Isaac before locking down `pair_selector.select_next_task` and `ranking.compute_rankings` signatures.
+**Acció:** parlar amb l'Isaac abans de tancar les signatures de `pair_selector.select_next_task` i `ranking.compute_rankings`.
 
-### 11.3. Issue #14 (idempotent DB loader, unassigned) is not a blocker
+### 11.3. La issue #14 (loader idempotent de BD, sense assignar) no és un bloquejant
 
-Without #14 there are no real votes in the DB to test against, but **Phase 1 (synthetic validation)** doesn't need them — we generate votes from planted skills. Real-DB integration belongs in Phase 2 / Phase 3.
+Sense la #14 no hi ha vots reals a la BD contra els quals fer tests, però la **Fase 1 (validació sintètica)** no els necessita — generem els vots a partir de skills sintètics. La integració amb la BD real correspon a la Fase 2 / Fase 3.
 
-### 11.4. Net effect on the design
+### 11.4. Efecte net sobre el disseny
 
-No breaking changes. Two updates to the plan:
+Cap canvi trencador. Dues actualitzacions al pla:
 
-- **§4** — add a follow-up line: "If PR #18 merges before Phase 2, switch the sampler to weighted random based on the diversity scores. The argument against adaptive sampling does not apply to frozen prompt-diversity priors (see §11.1)."
-- **§6.4 (test plan)** — add a test: `test_select_next_task_respects_diversity_weights()` if Approach B is taken.
-
----
+- **§4** — afegir una línia de seguiment: "Si el PR #18 es fa merge abans de la Fase 2, canviar el sampler a random ponderat basat en els scores de diversitat. L'argument contra el sampling adaptatiu no aplica als priors congelats sobre la diversitat dels prompts (vegeu §11.1)."
+- **§6.4 (pla de tests)** — afegir un test: `test_select_next_task_respects_diversity_weights()` si es pren l'aproximació B.
 
 ---
 
-## 12. Post-review log (2026-06-27)
+---
 
-An external adversarial review (sent to ChatGPT Pro) found a real bug and several places where the original design was less careful than it should have been. This section logs what changed and why.
+## 12. Registre post-revisió (2026-06-27)
 
-### 12.1. Bug fixed
+Una revisió adversarial externa (enviada a ChatGPT Pro) va trobar un bug real i diversos punts on el disseny original era menys curós del que hauria de ser. Aquesta secció registra què ha canviat i per què.
 
-The original §5.3 bootstrap code sorted skills inside each replicate and took `sorted[0] - sorted[1]`, which is non-negative by construction. This **falsely declares stability** when the best model swaps with the second across bootstrap replicates. Fix: identify the current best from the full-data fit, then track the **same** model's gap (signed, can go negative) in each replicate. New code in §5.3.
+### 12.1. Bug corregit
 
-### 12.2. Design changes confirmed and incorporated
+El codi bootstrap original de §5.3 ordenava els skills dins de cada rèplica i agafava `sorted[0] - sorted[1]`, cosa que és no negativa per construcció. Això **declara falsament l'estabilitat** quan el millor model s'intercanvia amb el segon entre rèpliques del bootstrap. Correcció: identificar el millor actual a partir de l'ajust amb totes les dades i, després, seguir el gap del **mateix** model (amb signe, pot ser negatiu) en cada rèplica. Codi nou a §5.3.
 
-| Change | Reason |
+### 12.2. Canvis de disseny confirmats i incorporats
+
+| Canvi | Motiu |
 |---|---|
-| iid random → **quota-balanced random** sampling | iid Poisson variance defeats the clustering analysis on a 13-vote/cell budget |
-| Module rename: `pair_selector.py` → `task_sampler.py` | We sample (category, prompt, pair, side), not just a pair |
-| Library: `choix` only in tests, scipy direct fit in production | `choix.ilsr_pairwise`'s `alpha` semantics are algorithm-dependent; scipy with explicit L2 is more transparent for ~30 LOC |
-| `ρ` demoted from estimated parameter → sensitivity slider | Beta-binomial MLE is unstable on 10 prompts × 13 votes; a single ρ hides multiple distinct sources of dependence |
-| Public margin language softened | "Under plausible ρ ∈ [0.1, 0.5], margin ≈ 13–23%" replaces "the true margin is 18%" |
-| TrueSkill/OpenSkill critique sharpened | Strong "they inflate variance" claim was wrong (drift is configurable); precise reason is they're tuned for online matchmaking |
-| Raw pairwise stats promoted to **primary public artifact** | At n=3 with ~133 votes/cell, BT variance saving is ~33% in symmetric case, drops to ~5% when one model dominates. Public communication is also cleaner without BT. |
-| Tie/neither handled separately | Tie = "both comparable"; neither = "both failed". Different signals, separate rates. |
-| Position bias / session clustering / cycle detection added to §6.6 | Independent sources of dependence that we should at least report on |
+| Aleatori iid → sampling **amb quota equilibrada** | La variància de Poisson de iid trenca l'anàlisi d'agrupació amb un pressupost de 13 vots/cel·la |
+| Rename de mòdul: `pair_selector.py` → `task_sampler.py` | Mostregem (categoria, prompt, parella, costat), no només una parella |
+| Biblioteca: `choix` només als tests, ajust directe amb scipy en producció | La semàntica de l'`alpha` de `choix.ilsr_pairwise` depèn de l'algorisme; scipy amb L2 explícit és més transparent per a ~30 línies |
+| `ρ` degradat de paràmetre estimat a slider de sensibilitat | L'MLE beta-binomial és inestable sobre 10 prompts × 13 vots; un ρ únic amaga múltiples fonts diferents de dependència |
+| Llenguatge del marge públic suavitzat | "Sota ρ plausible ∈ [0,1, 0,5], marge ≈ 13–23%" substitueix "el marge real és 18%" |
+| Crítica a TrueSkill/OpenSkill afinada | L'afirmació forta "inflen la variància" era errònia (el drift es pot configurar); el motiu precís és que estan afinades per matchmaking online |
+| Estadístiques pairwise brutes promocionades a **artefacte públic principal** | A n=3 amb ~133 vots/cel·la, l'estalvi de variància de BT és del ~33% en el cas simètric, baixa al ~5% quan un model domina. La comunicació pública també és més neta sense BT. |
+| Empat/cap gestionats per separat | Empat = "tots dos comparables"; cap = "tots dos han fallat". Senyals diferents, taxes separades. |
+| Biaix de posició / agrupació de sessions / detecció de cicles afegits a §6.6 | Fonts independents de dependència de les quals hem d'informar com a mínim |
 
-### 12.3. The Leaderboard Illusion paper — correction to my earlier reading
+### 12.3. El paper del Leaderboard Illusion — correcció a la meva lectura inicial
 
-I had framed adaptive sampling as walking into the same critique as Chatbot Arena. After reading Singh et al. 2025 directly (Section 6, Recommendation 4): **the paper recommends adopting** the Chiang et al. 2024 active sampling rule, arguing it "effectively prioritizes under-evaluated and high-variance pairs". The critique is about **undisclosed sampling rates that systematically over-represent proprietary providers**, not about adaptive sampling itself.
+Havia emmarcat el sampling adaptatiu com si caigués en la mateixa crítica que Chatbot Arena. Després de llegir Singh et al. 2025 directament (Secció 6, Recomanació 4): **el paper recomana adoptar** la regla de sampling actiu de Chiang et al. 2024, argumentant que "prioritza efectivament parelles infra-avaluades i d'alta variància". La crítica va contra **taxes de sampling no revelades que sobre-representen sistemàticament proveïdors propietaris**, no contra el sampling adaptatiu en si.
 
-This means `UncertaintyDrivenSampler` (the Chiang rule) is a perfectly defensible strategy if turned on later — with public disclosure. [`leaderboard_illusion_response.md`](leaderboard_illusion_response.md) has been updated accordingly.
+Això vol dir que `UncertaintyDrivenSampler` (la regla de Chiang) és una estratègia perfectament defensable si s'activa més endavant — amb disclosure pública. [`leaderboard_illusion_response.md`](leaderboard_illusion_response.md) s'ha actualitzat en conseqüència.
 
-### 12.4. Revised time estimate
+### 12.4. Estimació de temps revisada
 
-The original ~33 hours was optimistic. Realistic estimate after the review:
+Les ~33 hores originals eren optimistes. Estimació realista després de la revisió:
 
-| Phase | Hours |
+| Fase | Hores |
 |---|---|
-| Phase 0 (this design doc + review) | ~4 (already spent) |
-| Phase 1 (synthetic validation, including bootstrap correctness tests) | ~10 |
-| Phase 2 (implementation, 4 PRs) | ~25 |
-| Phase 4 (docs) | ~2 |
-| **Total (excluding #6 dependency)** | **~40** |
+| Fase 0 (aquest document de disseny + revisió) | ~4 (ja gastades) |
+| Fase 1 (validació sintètica, incloent-hi tests de correcció del bootstrap) | ~10 |
+| Fase 2 (implementació, 4 PRs) | ~25 |
+| Fase 4 (docs) | ~2 |
+| **Total (excloent-ne la dependència de #6)** | **~40** |
 
-Where it's likely to slip: tie/neither semantics with the team, complete-separation handling, deterministic scipy outputs across platforms, A/B side bookkeeping, the cluster-bootstrap edge cases (very few clusters, cycles).
+On és probable que s'estiri: semàntica d'empat/cap amb l'equip, gestió de separació completa, sortides scipy deterministes entre plataformes, comptabilitat del costat A/B, els casos límit del bootstrap de clusters (molt pocs clusters, cicles).
 
-### 12.5. Out of scope, but worth a future ticket
+### 12.5. Fora d'abast, però mereixerà un ticket futur
 
-- **Multi-level model** for prompt × model random effects (`u_{p,i}` term). Cleaner conceptually but needs PyMC/Stan, prior-driven with 10 prompts.
-- **Davidson tie model** for explicit tie probability in BT. Half-credit is a scoring convention; Davidson is a likelihood model. Defer to Fita 2+ when there's enough data to identify the tie parameter.
-- **Adversarial-voting defenses** beyond per-session rate limiting. The Singh paper's limitations section flags this as critical for community benchmarks; defer to v2 (when we have users).
+- **Model multinivell** per als efectes aleatoris prompt × model (terme `u_{p,i}`). Més net conceptualment però requereix PyMC/Stan, driven per priors amb 10 prompts.
+- **Model d'empat de Davidson** per a la probabilitat d'empat explícita a BT. El mig punt és una convenció d'scoring; Davidson és un model de verosimilitud. Ho ajornem a la Fita 2+ quan tinguem prou dades per identificar el paràmetre d'empat.
+- **Defenses contra vot adversarial** més enllà del rate limiting per sessió. La secció de limitacions del paper de Singh ho marca com a crític per als benchmarks comunitaris; ho ajornem a v2 (quan tinguem usuaris).
 
 ---
 
-## References
+## Referències
 
-- Project docs: [`README.md`](../README.md), [`projecte.md`](../projecte.md), [`pla_detallat.md`](../pla_detallat.md), [`AGENTS.md`](../AGENTS.md)
+- Documents del projecte: [`README.md`](../README.md), [`projecte.md`](../projecte.md), [`pla_detallat.md`](../pla_detallat.md), [`AGENTS.md`](../AGENTS.md)
 - Issue: [#7 Biblioteca de rànquing i selecció de parelles](https://github.com/Softcatala/arena-cat/issues/7)
-- Related open: [#6 microservei (Isaac)](https://github.com/Softcatala/arena-cat/issues/6), [#14 càrrega idempotent](https://github.com/Softcatala/arena-cat/issues/14), [PR #18 diversitat de prompts](https://github.com/Softcatala/arena-cat/pull/18)
-- Schema: [`backend/app/models.py`](../backend/app/models.py), [`docs/db_schema.md`](db_schema.md)
-- Sample-size analysis: [`analysis/dimensioning.py`](../analysis/dimensioning.py) and four graphs in `analysis/out/`
-- External: [choix docs](https://choix.lum.li/en/latest/), [Bradley-Terry on Wikipedia](https://en.wikipedia.org/wiki/Bradley%E2%80%93Terry_model), [Leaderboard Illusion paper](https://arxiv.org/abs/2504.20879)
+- Relacionats oberts: [#6 microservei (Isaac)](https://github.com/Softcatala/arena-cat/issues/6), [#14 càrrega idempotent](https://github.com/Softcatala/arena-cat/issues/14), [PR #18 diversitat de prompts](https://github.com/Softcatala/arena-cat/pull/18)
+- Esquema: [`backend/app/models.py`](../backend/app/models.py), [`docs/db_schema.md`](db_schema.md)
+- Anàlisi de dimensionament de mostra: [`analysis/dimensioning.py`](../analysis/dimensioning.py) i quatre gràfiques a `analysis/out/`
+- Extern: [documentació de choix](https://choix.lum.li/en/latest/), [Bradley-Terry a Wikipedia](https://en.wikipedia.org/wiki/Bradley%E2%80%93Terry_model), [paper del Leaderboard Illusion](https://arxiv.org/abs/2504.20879)

--- a/docs/T7_ranking_design.md
+++ b/docs/T7_ranking_design.md
@@ -1,0 +1,761 @@
+# T7 — Ranking library and pair selection: design proposal
+
+> Draft. Authored by Gerard Martínez Canelles. Pre-implementation document for [issue #7](https://github.com/Softcatala/arena-cat/issues/7). Branch: `feature/T7_ranking`.
+
+This document has **two audiences**:
+
+1. **Reviewers** (Jordi, the team) — sections 1, 6, 7, 8 are the executive summary, the proposed module split, the open questions, and the plan.
+2. **Gerard** (me, learning) — sections 2–5 are a long-form pedagogical walkthrough of the algorithms with worked examples in plain English. Skip if you already know Bradley-Terry / Elo / bootstrap CIs.
+
+---
+
+## Contents
+
+1. [Executive summary](#1-executive-summary)
+2. [What questions does the issue actually ask?](#2-what-questions-does-the-issue-actually-ask)
+3. [Crash course: how the ranking algorithms work](#3-crash-course-how-the-ranking-algorithms-work)
+   - [3.1. Raw pairwise win rates](#31-raw-pairwise-win-rates)
+   - [3.2. Bradley-Terry](#32-bradley-terry)
+   - [3.3. Elo](#33-elo)
+   - [3.4. TrueSkill / OpenSkill](#34-trueskill--openskill)
+   - [3.5. Side-by-side comparison](#35-side-by-side-comparison)
+4. [Pair selection: random vs adaptive](#4-pair-selection-random-vs-adaptive)
+5. [How do we know "we have enough votes"?](#5-how-do-we-know-we-have-enough-votes)
+6. [Proposed design](#6-proposed-design)
+7. [Open questions for the team](#7-open-questions-for-the-team)
+8. [Plan ahead](#8-plan-ahead)
+
+---
+
+## 1. Executive summary
+
+Issue #7 asks for a library that answers three questions:
+
+1. Which model pair should the next user evaluate?
+2. What is the current ranking?
+3. Have we collected enough votes to trust the ranking?
+
+After reading the project docs and the issue, my recommendation is:
+
+| Question | Recommendation for Fita 1 (n=3 models) |
+|---|---|
+| **Q1 — next pair** | **Quota-balanced randomization** over (category, prompt, unordered_pair, side). Pick uniformly among currently underfilled cells. Behind a `TaskSampler` protocol so we can swap in active sampling later. |
+| **Q2 — ranking** | **Raw pairwise stats as the primary public artifact**, with **per-category Bradley-Terry** as a secondary summary. BT fitted with our own ~30-line `scipy.optimize` solver, validated against `choix` in unit tests. |
+| **Q3 — confidence** | **Prompt-cluster bootstrap with fixed labels** from the original fit. Report P(best is best), CI for current best minus strongest competitor, bootstrap rank distribution. |
+| **Stopping rule** | `FixedBudgetRule` default for Fita 1 (we need the full dataset for the public release). `AdaptiveStoppingRule` implemented but not enabled — requires sequential-testing correction before production. |
+| **ρ estimation** | Demoted from stopping logic to **sensitivity analysis** (a slider in the simulador, not a fitted parameter). With 10 prompts × 13 votes, a beta-binomial MLE is unstable. |
+| **Library choice** | Direct `scipy.optimize` BT fit in production; `choix` as a test-time reference for validation only. TrueSkill/OpenSkill not used — they're optimized for online matchmaking, not transparent offline inference with cluster awareness. |
+
+**Why raw pairwise stats are primary, not BT:** for n=3 models with ~133 votes per cell, BT's variance reduction over raw pairwise is ~33% in the symmetric case and falls toward 5% when one model dominates. Public communication is also cleaner: "Gemma beat Qwen in 73 of 120 decisive votes (61%, 95% CI [52%, 69%])" requires no model. BT is a useful secondary check and starts paying off in Fita 2+ when n grows.
+
+**Why quota-balanced randomization, not iid uniform:** iid uniform over 90 (category × prompt × pair) cells with 1,200 votes gives Poisson variance per cell (≈3.6 SD on a mean of 13.3). After complaining about clustering, accepting that level of cell imbalance is self-defeating. Quota-balanced randomization is **not** outcome-adaptive — it depends only on accumulated counts, not on who's winning — so it doesn't trigger the *Leaderboard Illusion* critique.
+
+**Why TrueSkill/OpenSkill are wrong fit (precise version):** both libraries are configurable enough to set drift to zero — the strong claim "they always inflate variance" is wrong. The real critique is that they're **designed for online ranking and matchmaking in games**, not for transparent offline inference over a fixed evaluation design. They don't naturally handle prompt clustering, tie/neither semantics, or fixed-quota sampling — the things that actually matter for us.
+
+The substantive contribution of this task is **not the library choice** — it's the combination of **quota-balanced sampling** (to keep cells balanced) and **prompt-cluster bootstrap with fixed labels** (to get honest uncertainty estimates). The existing simulator's ±8.5% margin is a sensitivity calculation conditional on assumed ρ; under plausible ρ values (0.1–0.5) the per-cell margin is plausibly 13–23% (see [analysis/dimensioning.py](../analysis/dimensioning.py)).
+
+---
+
+## 2. What questions does the issue actually ask?
+
+The full task body from [issue #7](https://github.com/Softcatala/arena-cat/issues/7):
+
+> Implement a library that answers:
+> - Which is the next pair of models to evaluate for the user?
+> - What is the current ranking of the models?
+> - What confidence do we have in the current ranking / have we reached enough evaluations (per category)?
+>
+> Evaluate using openskill, trueskill or similar. Create simulation scripts.
+
+Reading carefully, this is **two separate concerns wedged into one issue**:
+
+| Concern | Type | Stakes |
+|---|---|---|
+| **Pair selection** (Q1) | Online, runs on every API request | Low — wrong choice slightly biases sampling |
+| **Ranking + confidence** (Q2, Q3) | Offline / periodic, runs on the full dataset | High — drives the public ranking and the stopping decision |
+
+These should be **two modules**, not one. They have different testing needs, different update frequencies, and don't have to share a library.
+
+---
+
+## 3. Crash course: how the ranking algorithms work
+
+This section is the long pedagogical walkthrough. Skip if you know these algorithms.
+
+### 3.1. Raw pairwise win rates
+
+**The simplest possible thing.** For every (model_A, model_B, category), count how many times A won and divide by total votes.
+
+#### Worked example (correcció category)
+
+Suppose after some voting we have:
+
+| Match-up | Votes for A | Votes for B | Ties |
+|---|---|---|---|
+| Qwen vs Salamandra | 73 | 47 | 10 |
+| Qwen vs Gemma | 60 | 60 | 10 |
+| Salamandra vs Gemma | 30 | 90 | 10 |
+
+(Ignoring ties for simplicity: many BT formulations drop them.)
+
+Raw win rates:
+- Qwen vs Salamandra: 73 / (73 + 47) = **60.8%** for Qwen
+- Qwen vs Gemma: 60 / 120 = **50.0%** (tie at population level)
+- Salamandra vs Gemma: 30 / 120 = **25.0%** for Salamandra (Gemma dominates)
+
+**What's good about this:** transparent, no model assumptions, easy to put a binomial confidence interval on each pair.
+
+**What's bad about this:**
+1. **No global ranking.** You have three independent comparisons; combining them into a single skill score is informal.
+2. **No transitivity sharing.** If Qwen beats Salamandra and Salamandra loses to Gemma, this evidence doesn't update our belief about Qwen vs Gemma.
+3. **No CIs across pairs.** You can put a CI on each pair, but combining them into "the ranking is reliable" requires another step.
+
+#### Confidence interval (Wilson, the right one to use)
+
+For a single pair with `wins` out of `n` votes:
+
+```python
+p_hat = wins / n
+ci_low, ci_high = wilson_ci(wins, n, confidence=0.95)
+```
+
+This is what the `simulador/index.html` is computing (approximately). The issue is that **n here is votes, not prompts** — so the CI is too tight when votes within a prompt are correlated. See section 5.
+
+---
+
+### 3.2. Bradley-Terry
+
+**The idea:** assign each model a single number — its **skill** `θ_i`. The probability that model A beats model B is:
+
+```
+P(A beats B) = exp(θ_A) / (exp(θ_A) + exp(θ_B))
+            = sigmoid(θ_A - θ_B)
+```
+
+This is just **logistic regression with model identity as the only feature**. If you've done classification in Python, you know this. If `θ_A = θ_B`, P(A wins) = 0.5. If `θ_A − θ_B = log(2) ≈ 0.69`, A wins 2/3 of the time. If the gap is `log(9) ≈ 2.2`, A wins 90% of the time.
+
+#### Worked example: fitting BT by hand-wavy intuition
+
+Using the data from §3.1, BT would assign skills like:
+
+| Model | Skill `θ` (illustrative) | Interpretation |
+|---|---|---|
+| Gemma | +0.6 | strongest |
+| Qwen | +0.2 | middle |
+| Salamandra | −0.8 | weakest |
+
+These don't have absolute meaning — only **differences** matter (BT is shift-invariant). What matters is `θ_Gemma − θ_Salamandra = 1.4`, which corresponds to `sigmoid(1.4) ≈ 80%` probability of Gemma winning, matching the 90/120 = 75% observed.
+
+#### How BT is fitted in practice
+
+Maximum likelihood, usually by **iterative algorithms** (MM, Newton, or simply gradient descent in PyTorch). The `choix` library does this for us:
+
+```python
+import choix
+
+# Build a list of (winner_id, loser_id) pairs, ignoring ties.
+data = [(qwen, salamandra)] * 73 + [(salamandra, qwen)] * 47 + ...
+
+# Fit BT
+skills = choix.ilsr_pairwise(n_models, data, alpha=0.01)
+# → array like [0.2, -0.8, 0.6] for [qwen, salamandra, gemma]
+```
+
+`ilsr_pairwise` = Iterative Luce Spectral Ranking, an efficient solver. `alpha` is a small regularizer to keep things stable when one model has 0 wins or losses.
+
+#### The transitivity argument (why BT is "better than raw")
+
+Imagine we have 100 votes on (Qwen vs Salamandra) and 100 on (Salamandra vs Gemma), but **only 5 on (Qwen vs Gemma)** because the random sampler hasn't hit it much yet.
+
+- **Raw approach:** for (Qwen vs Gemma), we have a CI based on n=5. Very wide.
+- **BT approach:** even with 5 direct votes, the skills `θ_Qwen` and `θ_Gemma` are both *anchored* by the 200 votes that involve Salamandra. The implied (Qwen vs Gemma) probability is much better estimated than 5 votes alone would suggest.
+
+This is the "transitivity savings" the README mentions. The savings grow with `log₂(n)/(n−1)`:
+
+| n models | BT reduction factor | Savings |
+|---|---|---|
+| 2 | 1.00 | 0% |
+| 3 | 0.79 | 21% |
+| 5 | 0.58 | 42% |
+| 10 | 0.37 | 63% |
+| 20 | 0.23 | 77% |
+
+For **Fita 1 (n=3), BT gives us a 21% reduction**. For Fita 2+ with 10+ models, it becomes much more valuable.
+
+#### When BT fails
+
+BT assumes a **single global axis** of skill. If reality is "Gemma is much better at correcció but Qwen is much better at traducció", a single global BT will smear both. **This is exactly why we fit BT per category, not globally** — see §6.
+
+---
+
+### 3.3. Elo
+
+**Same model as BT, but fitted online with a simple update rule.**
+
+Each model starts at e.g. 1500. After a match where A beats B:
+
+```
+expected_A = 1 / (1 + 10^((rating_B - rating_A) / 400))
+rating_A += K * (1 - expected_A)
+rating_B += K * (0 - expected_B)
+```
+
+Where K is a "learning rate" (typically 16–32 in chess).
+
+**Worked example:**
+- Both at 1500. A beats B.
+- `expected_A = 1 / (1 + 10^0) = 0.5`.
+- `rating_A += K * (1 - 0.5) = 0.5K`. With K=32, A goes to 1516, B drops to 1484.
+
+**Why Elo isn't the right primary tool for us:**
+
+1. **Order-dependent.** If you replay the same 200 votes in a different order, you get different final ratings. BT (fitted in batch) is order-independent.
+2. **The K parameter is arbitrary.** Too high → noisy ratings. Too low → ratings don't track the data. There's no principled way to set K for a snapshot evaluation.
+3. **The 400 scaling is a chess convention.** It's the same model as BT under the hood, just with a different parameterization (`log(10) / 400`).
+
+**Where Elo is useful for us:** as a **cheap online estimate** for pair-selection during voting, computed on the fly without re-fitting a full BT model. But the public ranking should use offline BT.
+
+LMSYS Chatbot Arena reports both — see their blog post on the method.
+
+---
+
+### 3.4. TrueSkill / OpenSkill
+
+**Bayesian extension of Elo where each player has a (mean, variance) instead of a single rating.**
+
+- TrueSkill: Microsoft, designed for Xbox Live matchmaking.
+- OpenSkill: open-source replacement, similar API.
+
+The mean is the estimate; the variance shrinks as more matches are observed. A new player starts with high variance ("we don't know"). After matches, the variance decreases.
+
+**The problem for us:** both libraries model **dynamic skill** — they assume a player's true skill drifts over time, and they have parameters like "dynamics factor" or "tau" that govern how much variance is *added back* after each match to prevent the system from getting too confident.
+
+But our models are **frozen snapshots**. Salamandra 7B's skill at correcció does not drift. Adding dynamics noise is not just unnecessary — it's actively harmful: it inflates variance and gives wider confidence intervals than the data justifies.
+
+**Conclusion:** TrueSkill/OpenSkill solve a problem we don't have. The issue's suggestion to use them probably reflects which libraries are best-known, not which fits the statistical setting.
+
+---
+
+### 3.5. Side-by-side comparison
+
+| Property | Raw win rates | Bradley-Terry | Elo | TrueSkill/OpenSkill |
+|---|---|---|---|---|
+| Global ranking | ❌ | ✅ | ✅ | ✅ |
+| Transitivity sharing | ❌ | ✅ | ✅ | ✅ |
+| Order-independent | ✅ | ✅ | ❌ | ❌ |
+| Online updates | n/a | costly (refit) | cheap | cheap |
+| Models dynamic skill | n/a | ❌ | weakly | ✅ |
+| Easy CI from bootstrap | ✅ | ✅ | trickier | trickier |
+| Fits our setting | partial | **best** | OK for online | overkill |
+
+---
+
+## 4. Task selection (correcting an earlier misreading)
+
+When a user opens the app, the server must pick a **task** — a tuple of `(category, prompt, unordered_model_pair, side_assignment)` — to show them. The unit is not just a model pair: the prompt, the category, and which model is shown on the left vs right all matter.
+
+### 4.1. Three candidates
+
+| Strategy | How it picks | Pros | Cons |
+|---|---|---|---|
+| **iid uniform random** | Sample uniformly among all 90 (category × prompt × pair) cells, randomize side | Simple, unbiased | iid creates Poisson cell-count variance — some cells will have 5 votes, others 25, on a budget of 13. Self-defeating given our clustering concern. |
+| **Quota-balanced random** | Sample uniformly among cells currently below the target count, randomize side. Avoid showing the same session the same cell twice. | Same statistical properties as uniform in expectation; cell counts converge to exactly equal. | Slightly more state in the sampler. |
+| **Active sampling (Chiang 2024 rule)** | Probability ∝ `√(σ²/n) − √(σ²/(n+1))` — favors under-evaluated, high-variance pairs | ~30%+ vote savings; what Chiang and Singh both recommend. | Requires running BT estimate at sampling time; needs disclosure. |
+
+### 4.2. The Leaderboard Illusion paper: what it actually says
+
+I read Singh et al. 2025 carefully. **My earlier framing in this doc was wrong.** The paper's critique is **not** "adaptive sampling is bad". It is:
+
+> *"undisclosed sampling rates that systematically over-represent a handful of proprietary providers"* (Section 4.1, paraphrased).
+
+The paper's **Recommendation 4** is **to implement** the active sampling rule from Chiang et al. 2024 (FastChat Section 5, Eq. 9), arguing it "effectively prioritizes under-evaluated and high-variance pairs, aligning sampling with the goal of rapidly reducing uncertainty in rankings". The paper criticizes Chatbot Arena for **claiming** to do this but not actually deploying it.
+
+So adaptive sampling is fine if: (a) it's based on uncertainty / under-sampling, not on rank closeness for its own sake, and (b) the strategy is publicly disclosed.
+
+### 4.3. Recommendation
+
+**For Fita 1: quota-balanced randomization, behind a `TaskSampler` protocol.** Reasons:
+- It eliminates the iid-uniform imbalance problem essentially for free.
+- It's not adaptive in any sense and has no disclosure burden.
+- The savings from active sampling at n=3 with a fixed 1,200-vote budget are modest. We're better off spending complexity on bootstrap correctness.
+
+**For Fita 2+: active sampling becomes attractive.** The Chiang et al. rule is implemented as a second strategy (`UncertaintyDrivenSampler`) and can be turned on via config, with the strategy disclosed on the public ranking page.
+
+```python
+# task_sampler.py
+
+class TaskSampler(Protocol):
+    """Estratègia per triar la propera tasca completa: (categoria, prompt, parella, costat)."""
+    def select_next_task(self, session: Session) -> Task: ...
+
+
+class QuotaBalancedSampler:
+    """Tria uniformement entre cel·les (categoria, prompt, parella) que encara no han
+    arribat al quota. Estratègia per defecte a la Fita 1."""
+
+class UncertaintyDrivenSampler:
+    """Implementa la regla de Chiang et al. 2024 (FastChat §5, eq. 9):
+    P(a) ∝ √(σ²/n_a) − √(σ²/(n_a+1))
+    Requereix una estimació actual de skills. Cal disclosure pública si s'activa."""
+
+class DiversityWeightedSampler:
+    """Quota-balanced però amb pesos dels prompts segons la diversitat dels outputs
+    (vegeu §11.1). Els pesos són pre-calculats i no depenen de cap rànquing."""
+```
+
+**Side randomization is mandatory for all strategies** to avoid position bias. The sampler picks `side_assignment ∈ {A, B}` uniformly per task and does not canonicalize the order in the DB.
+
+---
+
+## 5. How do we know "we have enough votes"?
+
+This is the **most underspecified** part of issue #7 and where careful statistics matters most.
+
+### 5.1. The naive answer (what the simulator does)
+
+For each (pair × category) cell, compute a binomial CI on the win rate:
+
+```python
+margin = z * sqrt(0.25 / n_votes)  # worst case at p=0.5
+```
+
+For 133 votes → 8.5% margin. **Stop when margin < target.**
+
+This is wrong when votes within a prompt are correlated, which they are.
+
+### 5.2. The cluster-aware answer
+
+The Kish design effect formula:
+
+```
+N_effective = N_raw / (1 + (k − 1) * ρ)
+```
+
+- `k` = votes per prompt
+- `ρ` = intra-prompt correlation (how much the prompt determines the verdict)
+
+For Fita 1 with ρ ≈ 0.3, the per-cell margin is **plausibly 18%, not 8.5%** — but note this is a sensitivity calculation conditional on assumed ρ, not an empirical truth. With only 10 prompt clusters per category, even with the design effect properly accounted for, the small number of clusters limits the precision of any uncertainty estimate. The asymptotic z = 1.96 approximation is also optimistic at 10 clusters.
+
+See the full analysis in [analysis/dimensioning.py](../analysis/dimensioning.py) and the four graphs in `analysis/out/`. The right way to communicate this publicly is **"under plausible ρ ∈ [0.1, 0.5], the margin is 13–23%"**, not "the true margin is 18%".
+
+### 5.3. Operational confidence rule (and a bug fix)
+
+**The actual question we want to answer per category:** "Is our currently-best model reliably better than the next-best competitor?"
+
+This is *not* the same as "is the gap between rank 1 and rank 2 large?", because rank 1 and rank 2 can swap across bootstrap replicates. An earlier draft of this doc had a bug here: sorting skills inside each bootstrap replicate forces the gap to be non-negative by construction, which falsely declares stability even when the ranking is unstable.
+
+**The fixed-labels cluster bootstrap (correct version):**
+
+```python
+# Original: 10 prompts per category (each with many votes)
+# Step 1: Fit BT once on the full data to identify the *current* best.
+theta_hat = fit_bt(all_votes_in_category)
+best_model = argmax(theta_hat)
+competitor_models = [m for m in models if m != best_model]
+
+# Step 2: Resample whole prompts with replacement, refit BT each time,
+# track the SAME model's gap (not the resampled rank 1).
+deltas = []
+for _ in range(n_bootstrap):
+    sampled_prompts = random.choices(prompts_in_category, k=len(prompts_in_category))
+    sampled_votes = flatten(p.votes for p in sampled_prompts)
+    theta_b = fit_bt(sampled_votes)
+    delta_b = theta_b[best_model] - max(theta_b[m] for m in competitor_models)
+    deltas.append(delta_b)  # CAN BE NEGATIVE — that's the point
+
+# Step 3: Two complementary summaries.
+ci_lo, ci_hi = np.percentile(deltas, [2.5, 97.5])
+p_best_is_best = np.mean([d > 0 for d in deltas])
+ranking_is_stable = ci_lo > 0
+```
+
+**Why this works:** if the current best is genuinely better, most bootstrap replicates will still show it ahead → `p_best_is_best` close to 1 and `ci_lo > 0`. If the current best is barely ahead and the ranking is fragile, many replicates will show a different model ahead → `delta_b` goes negative in those replicates → `ci_lo < 0` and `p_best_is_best` near 0.5.
+
+**Two complementary numbers, not one:**
+- `p_best_is_best` — easy to communicate. "Gemma is the best model in correcció with 87% confidence."
+- `ci_lo, ci_hi` — formal CI on the skill gap. Used in the stopping rule.
+
+**Important caveats** (worth flagging in any public communication):
+1. With **only 10 prompt clusters**, the cluster bootstrap is more honest than iid bootstrap, but it is not magic — cluster bootstrap with very few clusters has known small-sample issues.
+2. The bootstrap accounts for **prompt-level dependence** only. **Session-level dependence** (one volunteer casting many votes) is a separate source of correlation we should report on but not fold into the bootstrap until v2 (when we have users).
+3. The rule "**Pr(current best is best) > 95%**" is *not* the same as "**we have detected a statistically significant gap**" — be careful in public framing.
+
+### 5.4. ρ is not in the public confidence story
+
+`ρ` stays as a **sensitivity slider** in the simulador and an internal diagnostic. We do **not** fit a single ρ from the data and publish a confidence claim that depends on it — with 10 prompts × 13 votes, the beta-binomial MLE is unstable and a single ρ would hide several distinct sources of dependence (prompt difficulty, model-prompt interaction, session effects, position bias, category ambiguity). Treat ρ as a "what-if" tool, not as a parameter we estimate.
+
+---
+
+## 6. Proposed design
+
+### 6.1. Module split
+
+```
+backend/app/ranking/
+    __init__.py
+    task_sampler.py     # Q1: pick next (category, prompt, pair, side) — quota-balanced default
+    ranking.py          # Q2: raw pairwise stats + per-category BT (scipy.optimize, ~30 LOC)
+    confidence.py       # Q3: fixed-label cluster bootstrap, P(best is best), stopping rules
+    types.py            # dataclasses, kept free of SQLAlchemy
+```
+
+**Design constraint:** the core types and functions consume plain dataclasses or dataframes, not SQLAlchemy ORM rows. The API layer is responsible for translating ORM rows into core types. This keeps the math testable in isolation and avoids coupling ranking logic to the DB session.
+
+Plus simulation scripts under `scripts/`:
+
+```
+scripts/
+    simulate_ranking.py     # Drive the full pipeline end-to-end on synthetic data
+    benchmark_methods.py    # Compare BT vs raw win rates on real-ish data
+```
+
+### 6.2. Public API (sketch)
+
+#### Task sampler — Strategy pattern
+
+To avoid technical debt later, we expose a `TaskSampler` protocol with three interchangeable implementations. The microservice picks one at startup via configuration. We start with `QuotaBalancedSampler` for Fita 1 and can switch to weighted or active sampling later without API changes.
+
+```python
+# task_sampler.py
+
+class TaskSampler(Protocol):
+    """Estratègia per triar la propera tasca completa:
+    (categoria, prompt, parella, costat_A_o_B)."""
+    def select_next_task(self, session_id: str | None) -> Task: ...
+
+
+class QuotaBalancedSampler:
+    """Tria uniformement entre cel·les (categoria, prompt, parella) per sota del quota.
+    Randomitza el costat (A/B). Evita repetir la mateixa cel·la per a una sessió.
+    Estratègia per defecte a la Fita 1."""
+
+class DiversityWeightedSampler:
+    """Quota-balanced, però amb pesos pre-calculats segons la diversitat
+    dels outputs dels models per a aquell prompt (vegeu §11.1).
+    Els pesos són fixos durant la campanya — no depenen dels vots acumulats."""
+
+class UncertaintyDrivenSampler:
+    """Implementa la regla d'active sampling de Chiang et al. 2024 (FastChat §5, eq. 9):
+    P(a) ∝ √(σ²/n_a) − √(σ²/(n_a+1))
+    Recomanat per Singh et al. 2025 com a remei a les biaixos de sampling.
+    Requereix una estimació actual de skills; cal disclosure pública si s'activa."""
+
+
+# ranking.py
+@dataclass
+class CategoryRanking:
+    category_code: str
+    bt_skills: dict[str, float]              # model → BT skill
+    raw_win_rates: dict[tuple[str, str], float]  # (a, b) → P(a beats b)
+    n_votes: int
+    n_prompts: int
+
+def compute_rankings(session: Session) -> list[CategoryRanking]:
+    """Fit BT i calcula les estadístiques per cada categoria."""
+    ...
+
+# confidence.py
+# Hi ha dues maneres d'usar la confiança:
+#   - "report-only": col·lectar votes fins al budget i reportar la confiança final.
+#   - "stopping rule": parar quan el CI bootstrap sobre el gap rank1-rank2 exclou zero.
+# Implementem totes dues; la microservei tria via configuració.
+@dataclass
+class ConfidenceReport:
+    category_code: str
+    rank1_vs_rank2_skill_gap_ci: tuple[float, float]
+    is_ranking_stable: bool
+    estimated_rho: float
+    naive_margin: float
+    clustered_margin: float
+
+def assess_confidence(
+    session: Session,
+    category_code: str,
+    n_bootstrap: int = 1000,
+) -> ConfidenceReport:
+    """Bootstrap clustered per categoria; estima ρ a partir de les dades."""
+    ...
+
+
+class StoppingRule(Protocol):
+    """Decideix si una categoria ha rebut prou vots."""
+    def should_stop(self, session: Session, category_code: str) -> bool: ...
+
+
+class FixedBudgetRule:
+    """Para quan s'arriba a `votes_target` per cel·la. Estratègia per defecte a la Fita 1.
+    Permet alliberar un dataset complet i comparable entre categories."""
+    def __init__(self, votes_target_per_cell: int = 133): ...
+
+class AdaptiveStoppingRule:
+    """Para una categoria quan el CI bootstrap sobre rank1-rank2 exclou zero.
+    Més eficient en hores humanes; introdueix biaix de 'peeking' si no es controla
+    amb correcció seqüencial (alpha-spending) — implementació posterior si cal."""
+    def __init__(self, min_votes_per_cell: int = 50, alpha: float = 0.05): ...
+```
+
+### 6.3. Dependencies to add
+
+```toml
+[project.dependencies]
+numpy = "^1.26"
+scipy = "^1.11"             # BT MLE via scipy.optimize.minimize; Wilson CIs; bootstrap stats
+
+[project.optional-dependencies]
+dev = [
+    "choix = ^0.3",         # Reference BT implementation; used only in unit tests
+]
+```
+
+**Why scipy in production, choix only in tests.** The BT log-likelihood is ~30 lines in pure scipy with a sum-to-zero constraint and an explicit L2 regularization parameter `alpha` whose meaning is unambiguous. `choix` is excellent but its `alpha` semantics are algorithm-dependent (pairwise pseudo-counts in MM solvers, L2/Gaussian in scipy-based solvers), which makes it slightly less transparent for our use case. We use it in unit tests to validate our scipy fit against an independent implementation on planted data.
+
+**Complete separation guard.** If a model wins 0 or all decisive comparisons against another model in some category (possible with sparse data), the plain BT MLE diverges. The L2 regularization handles this gracefully; we test for it explicitly.
+
+No frontend changes. No DB changes (the existing schema in `models.py` is sufficient).
+
+### 6.4. TDD plan
+
+Following the project convention (`AGENTS.md`), tests come first. In English identifiers, Catalan docstrings:
+
+```python
+# tests/test_pair_selector.py
+def test_select_next_task_returns_two_distinct_models():
+    """Comprova que la parella retornada té dos models diferents."""
+
+def test_select_next_task_is_uniform_over_pairs():
+    """Sobre molts mostratges, la distribució de parelles és aproximadament uniforme."""
+
+# tests/test_ranking.py
+def test_bt_recovers_planted_skills():
+    """Amb dades sintètiques generades amb skills coneguts, BT els recupera dins l'error."""
+
+def test_bt_handles_tie_votes():
+    """Els empats no fan petar el solver; opcionalment es descompten o es divideixen."""
+
+# tests/test_confidence.py
+def test_clustered_bootstrap_wider_than_naive():
+    """Quan ρ > 0, el CI clusteritzat és més ampli que el binomial."""
+
+def test_stable_ranking_with_decisive_data():
+    """Si un model guanya el 90% de votes a tots els altres, is_ranking_stable=True."""
+
+def test_unstable_ranking_with_coin_flip_data():
+    """Si totes les parelles són 50/50, is_ranking_stable=False."""
+```
+
+### 6.5. Why this design beats the literal issue #7
+
+| What issue #7 says | What we propose | Why |
+|---|---|---|
+| "Use openskill / trueskill" | Direct scipy BT fit + choix-as-test-reference | openskill / trueskill are tuned for online matchmaking, not transparent offline inference |
+| Single library | Three modules (sampler, ranking, confidence) | Different stakes, different test patterns. Sampler doesn't depend on BT; BT doesn't depend on bootstrap. |
+| "Confidence in the ranking" | **Fixed-label** cluster bootstrap on `θ_best − max(θ_others)`, plus P(best is best) | Earlier "sort-and-take-top-2-gap" version had a sign bug; this one allows negative deltas and correctly reflects rank instability |
+| Implicit: iid uniform sampling | Quota-balanced randomization | iid creates Poisson cell imbalance on small budgets; quota-balanced doesn't trigger Leaderboard Illusion either way |
+| Simulation scripts | Plus benchmark of BT vs raw + adversarial cases | We show empirically that BT savings are ~33% in the symmetric case at n=3, falling toward 5% when one model dominates |
+
+### 6.6. Other product / methodology considerations
+
+| Concern | Handling |
+|---|---|
+| **Position bias (A vs B side)** | Side randomized per task by the sampler. Audit metric: per-model A-vs-B win-rate difference, reported in `confidence.py` outputs. |
+| **Session-level clustering** | `session_id` tracked, reported as a concentration metric (max votes per session, Herfindahl index). Not folded into the bootstrap until v2 introduces users. |
+| **Tie vs neither** | Reported as **separate** rates. For BT input: drop both. For raw stats: half-credit for tie, exclude neither (not half-credit, because neither means "neither is acceptable" not "they're equivalent"). |
+| **Category code immutability** | `cultura → reformulacio` (commit `439463a`) is a real rename. Category **codes** must be immutable for longitudinal analysis; display names can change. Flag this convention in `AGENTS.md` and our module README. |
+| **Model versioning in public outputs** | The public ranking exports `model + inference_metadata.{seed, temperature, top_p, quantization, model_version}` so the result can't be retroactively attributed to a different checkpoint. The data is already in the schema (`Response.inference_metadata`). |
+| **Cycle detection** | With n=3 raw pairwise can produce a cycle (A>B>C>A) that BT smooths away. Report when this happens — it's a meaningful signal about heterogeneity, not a bug. |
+
+---
+
+## 7. Open questions for the team
+
+Before implementation starts, I'd like to confirm:
+
+**Q1.** Do we want **per-category** rankings, **global**, or **both**? The README implies per-category but doesn't say it explicitly.
+> **My recommendation:** per-category is the product question. Global is a nice-to-have.
+
+**Q2.** Is the team OK with **random uniform** pair selection, or do you want adaptive? I argue strongly for random — see §4.
+> **My recommendation:** implement **both** behind a `PairSelector` protocol (§6.2) and ship `UniformRandomSelector` as the Fita 1 default. This way we can switch to adaptive later via config without a new PR. Adaptive will require public disclosure to avoid the Leaderboard Illusion critique (see `leaderboard_illusion_response.md`).
+
+**Q3.** How do we handle **ties and "neither"** votes? Three options:
+- (a) Drop them entirely.
+- (b) Count a tie as half a win for each side.
+- (c) Model ties explicitly with a "tie threshold" parameter (Rao-Kupper extension of BT).
+> **My recommendation:** (b) for raw win rates, (a) for BT (it's the standard).
+
+**Q4.** What's the **stopping criterion** for Fita 1? Hit the 1,200-vote target regardless, or stop early per-category if the ranking stabilizes?
+> **My recommendation:** implement **both** behind a `StoppingRule` protocol (§6.2) and ship `FixedBudgetRule` as the Fita 1 default — we want the full dataset for the public release (`projecte.md` §6.2). `AdaptiveStoppingRule` is wired up for later use, but requires sequential-testing corrections (alpha-spending) before production use to avoid the "peeking" bias.
+
+**Q5.** The "Leaderboard Illusion" concern in the bibliography — Arena Cat's response to each critique is documented in [`leaderboard_illusion_response.md`](leaderboard_illusion_response.md).
+
+---
+
+## 8. Plan ahead
+
+### Phase 0 — Alignment (this doc + review)
+- ✅ Branch `feature/T7_ranking` created.
+- ⏳ Post this doc as a comment on issue #7 and request feedback from Jordi.
+- ⏳ Resolve the 5 open questions in §7.
+
+### Phase 1 — Synthetic validation (no production code yet)
+- Write `scripts/simulate_ranking.py` that generates synthetic votes from known model skills with a given ρ.
+- Confirm that the cluster bootstrap recovers the right CI width.
+- Reproduce the 21% BT savings empirically for n=3 models.
+- This is the work that lets us say "this design works" *before* anyone uses it.
+
+### Phase 2 — Implementation (TDD, small PRs)
+- PR 1: `pair_selector.py` + tests. Trivial; opens the door.
+- PR 2: `ranking.py` (BT per category + raw stats) + tests.
+- PR 3: `confidence.py` (cluster bootstrap, ρ estimation, stopping rule) + tests.
+- PR 4: Integration test that wires all three modules together on seeded data.
+
+### Phase 3 — Integration with the microservice (issue #6)
+- Once issue #6's FastAPI service exists, expose three endpoints:
+  - `GET /api/task` calls `pair_selector.select_next_task`.
+  - `GET /api/stats` calls `ranking.compute_rankings` + `confidence.assess_confidence`.
+  - The `POST /api/vote` already exists per `pla_detallat.md`; just writes to the DB.
+- This phase is **out of scope for this task** but the API surface is designed so it slots in cleanly.
+
+### Phase 4 — Documentation
+- Update `docs/db_schema.md` if any new tables/views are needed (currently I think we can compute everything from `votes` + `responses` + `prompts` + `categories`).
+- Add a short `backend/app/ranking/README.md` explaining the three modules.
+
+### Estimated effort
+
+| Phase | Hours |
+|---|---|
+| Phase 0 (alignment) | ~3 |
+| Phase 1 (synthetic validation) | ~8 |
+| Phase 2 (implementation, 4 PRs) | ~20 |
+| Phase 3 (FastAPI wiring) | depends on #6 |
+| Phase 4 (docs) | ~2 |
+| **Total (excluding #6 dependency)** | **~33 hours** |
+
+This fits the ~120-hour Fita 1 budget called out in [README.md](../README.md#fita-1-prova-de-concepte).
+
+---
+
+## 11. Updates after rebase onto main (2026-06-27)
+
+The branch was rebased onto `origin/main` and the issue / PR list was re-checked. Two commits had landed on main since the doc was written; neither affects this design directly:
+
+- `00c5228` — disabled reasoning in `scripts/inferencia.py`, added per-model inference time tracking.
+- `39bd981` — removed the `contributors-readme-action` workflow.
+
+Three open items on the repo deserve a mention because they touch our scope.
+
+### 11.1. PR #18 — "Càlcul de diversitat dels prompts" (open, Jordi)
+
+Adds two scripts:
+- `scripts/metriques.py` — computes pairwise distances between the three models' outputs on the same prompt, using **chrF** (character n-gram similarity) and **Levenshtein**, both normalized to a 0–1 distance.
+- `scripts/analitza_inferencies.py` — produces a `results.txt` that ranks the 30 prompts by how *discriminating* they are (prompts where the three models produce more divergent outputs rank higher).
+
+**Why this matters for our pair selector.** If two models produce nearly identical outputs for a given prompt, a human evaluator cannot meaningfully prefer one. The vote becomes near-50/50 noise, which:
+- Wastes human time.
+- Inflates the intra-prompt correlation `ρ` we worried about in §5, because the random noise dominates the within-prompt signal.
+
+This is genuinely useful **prior information** that's computable offline, before any vote is collected.
+
+**Two ways to use it (both compatible with §4's "no Leaderboard Illusion" stance):**
+
+| Approach | What it does | Trade-off |
+|---|---|---|
+| **A — Filter** | Drop prompts where pairwise output similarity is above a threshold (e.g., `chrF_d < 0.15`) | Cleaner stats; smaller dataset |
+| **B — Weighted random sampling** | Down-weight (but don't exclude) non-discriminating prompts in the random sampler | Keeps all prompts; biases toward informative ones |
+
+**Important — why this is NOT adaptive sampling in the harmful sense.** The diversity weights are:
+- Computed **once** from the pre-generated model outputs.
+- **Frozen** before voting starts.
+- **Independent** of the current ranking estimate.
+
+The Leaderboard Illusion critique targets samplers that bias toward currently-close-in-ranking pairs *based on accumulating vote data*. A frozen prior on prompt informativeness doesn't do that — it's the same logic as power analysis for test selection, which is standard practice.
+
+**My recommendation:** Once PR #18 merges, use `DiversityWeightedSampler` (the third strategy in §6.2) as an optional config — quota-balanced randomization, but with prompts within each (category, pair) cell sampled in proportion to their pre-computed diversity scores. Implementation in `task_sampler.py`:
+
+```python
+# Per (category × pair) cell, pick prompts according to diversity-weighted quota.
+# Weights are computed once at startup from PR #18's output, frozen for the campaign.
+```
+
+If PR #18 doesn't merge, fall back to plain `QuotaBalancedSampler` (uniform among under-quota cells). No code change required.
+
+**Open question for the team:** is Approach B acceptable, or do you want strict uniform for maximum transparency? My weak preference is B because it makes better use of the volunteer budget.
+
+### 11.2. Issue #6 (microservice) is assigned to Isaac Nicolas
+
+The downstream consumer of our library. Worth coordinating once we land Phase 1 so the API surface is what he needs. **Not verified yet:** whether Isaac has started, whether a draft API contract exists.
+
+**Action:** ping Isaac before locking down `pair_selector.select_next_task` and `ranking.compute_rankings` signatures.
+
+### 11.3. Issue #14 (idempotent DB loader, unassigned) is not a blocker
+
+Without #14 there are no real votes in the DB to test against, but **Phase 1 (synthetic validation)** doesn't need them — we generate votes from planted skills. Real-DB integration belongs in Phase 2 / Phase 3.
+
+### 11.4. Net effect on the design
+
+No breaking changes. Two updates to the plan:
+
+- **§4** — add a follow-up line: "If PR #18 merges before Phase 2, switch the sampler to weighted random based on the diversity scores. The argument against adaptive sampling does not apply to frozen prompt-diversity priors (see §11.1)."
+- **§6.4 (test plan)** — add a test: `test_select_next_task_respects_diversity_weights()` if Approach B is taken.
+
+---
+
+---
+
+## 12. Post-review log (2026-06-27)
+
+An external adversarial review (sent to ChatGPT Pro) found a real bug and several places where the original design was less careful than it should have been. This section logs what changed and why.
+
+### 12.1. Bug fixed
+
+The original §5.3 bootstrap code sorted skills inside each replicate and took `sorted[0] - sorted[1]`, which is non-negative by construction. This **falsely declares stability** when the best model swaps with the second across bootstrap replicates. Fix: identify the current best from the full-data fit, then track the **same** model's gap (signed, can go negative) in each replicate. New code in §5.3.
+
+### 12.2. Design changes confirmed and incorporated
+
+| Change | Reason |
+|---|---|
+| iid random → **quota-balanced random** sampling | iid Poisson variance defeats the clustering analysis on a 13-vote/cell budget |
+| Module rename: `pair_selector.py` → `task_sampler.py` | We sample (category, prompt, pair, side), not just a pair |
+| Library: `choix` only in tests, scipy direct fit in production | `choix.ilsr_pairwise`'s `alpha` semantics are algorithm-dependent; scipy with explicit L2 is more transparent for ~30 LOC |
+| `ρ` demoted from estimated parameter → sensitivity slider | Beta-binomial MLE is unstable on 10 prompts × 13 votes; a single ρ hides multiple distinct sources of dependence |
+| Public margin language softened | "Under plausible ρ ∈ [0.1, 0.5], margin ≈ 13–23%" replaces "the true margin is 18%" |
+| TrueSkill/OpenSkill critique sharpened | Strong "they inflate variance" claim was wrong (drift is configurable); precise reason is they're tuned for online matchmaking |
+| Raw pairwise stats promoted to **primary public artifact** | At n=3 with ~133 votes/cell, BT variance saving is ~33% in symmetric case, drops to ~5% when one model dominates. Public communication is also cleaner without BT. |
+| Tie/neither handled separately | Tie = "both comparable"; neither = "both failed". Different signals, separate rates. |
+| Position bias / session clustering / cycle detection added to §6.6 | Independent sources of dependence that we should at least report on |
+
+### 12.3. The Leaderboard Illusion paper — correction to my earlier reading
+
+I had framed adaptive sampling as walking into the same critique as Chatbot Arena. After reading Singh et al. 2025 directly (Section 6, Recommendation 4): **the paper recommends adopting** the Chiang et al. 2024 active sampling rule, arguing it "effectively prioritizes under-evaluated and high-variance pairs". The critique is about **undisclosed sampling rates that systematically over-represent proprietary providers**, not about adaptive sampling itself.
+
+This means `UncertaintyDrivenSampler` (the Chiang rule) is a perfectly defensible strategy if turned on later — with public disclosure. [`leaderboard_illusion_response.md`](leaderboard_illusion_response.md) has been updated accordingly.
+
+### 12.4. Revised time estimate
+
+The original ~33 hours was optimistic. Realistic estimate after the review:
+
+| Phase | Hours |
+|---|---|
+| Phase 0 (this design doc + review) | ~4 (already spent) |
+| Phase 1 (synthetic validation, including bootstrap correctness tests) | ~10 |
+| Phase 2 (implementation, 4 PRs) | ~25 |
+| Phase 4 (docs) | ~2 |
+| **Total (excluding #6 dependency)** | **~40** |
+
+Where it's likely to slip: tie/neither semantics with the team, complete-separation handling, deterministic scipy outputs across platforms, A/B side bookkeeping, the cluster-bootstrap edge cases (very few clusters, cycles).
+
+### 12.5. Out of scope, but worth a future ticket
+
+- **Multi-level model** for prompt × model random effects (`u_{p,i}` term). Cleaner conceptually but needs PyMC/Stan, prior-driven with 10 prompts.
+- **Davidson tie model** for explicit tie probability in BT. Half-credit is a scoring convention; Davidson is a likelihood model. Defer to Fita 2+ when there's enough data to identify the tie parameter.
+- **Adversarial-voting defenses** beyond per-session rate limiting. The Singh paper's limitations section flags this as critical for community benchmarks; defer to v2 (when we have users).
+
+---
+
+## References
+
+- Project docs: [`README.md`](../README.md), [`projecte.md`](../projecte.md), [`pla_detallat.md`](../pla_detallat.md), [`AGENTS.md`](../AGENTS.md)
+- Issue: [#7 Biblioteca de rànquing i selecció de parelles](https://github.com/Softcatala/arena-cat/issues/7)
+- Related open: [#6 microservei (Isaac)](https://github.com/Softcatala/arena-cat/issues/6), [#14 càrrega idempotent](https://github.com/Softcatala/arena-cat/issues/14), [PR #18 diversitat de prompts](https://github.com/Softcatala/arena-cat/pull/18)
+- Schema: [`backend/app/models.py`](../backend/app/models.py), [`docs/db_schema.md`](db_schema.md)
+- Sample-size analysis: [`analysis/dimensioning.py`](../analysis/dimensioning.py) and four graphs in `analysis/out/`
+- External: [choix docs](https://choix.lum.li/en/latest/), [Bradley-Terry on Wikipedia](https://en.wikipedia.org/wiki/Bradley%E2%80%93Terry_model), [Leaderboard Illusion paper](https://arxiv.org/abs/2504.20879)


### PR DESCRIPTION
Tanca la tasca #7. Aquesta biblioteca respon a les tres preguntes que demana la *issue*; la microservei web (#6, @isaacnicolas) la consumirà.

## Què aporta

Tres funcions públiques a `backend/app/ranking/`:

1. **`sampler.select_next_task(session, category_code)`** — tria la propera tasca a mostrar a un usuari amb una estratègia *quota-balanced*: busca les cel·les (prompt + parella de models) que actualment empaten al recompte mínim de vots i en tria una a l'atzar; també randomitza l'ordre A/B per evitar biaix de posició. No depèn de l'estat del model BT, així que cada vot omple el buit més gran sense crear biaixos. Cost: ~10 ms per crida (només llegeix recomptes).

2. **`ranking.compute_ranking(session, category_code)`** — per cada categoria, ajusta Bradley-Terry sobre tots els vots decisius i també retorna les taxes brutes de victòria per parella. Detecta cicles a 3 bandes (A>B>C>A) i els marca explícitament. Cost: ~30 ms (un sol ajust BT).

3. **`confidence.assess_confidence(session, category_code)`** — bootstrap clusteritzat amb etiquetes fixes sobre el gap entre el rànquing #1 i el millor competidor. Re-mostreja prompts sencers (no vots individuals) per respectar la dependència intra-prompt. Retorna `p_best_is_best`, un CI amb signe, i una bandera `is_stable` com a regla d'aturada operativa. Cost: ~5 segons (1000 ajustos BT) — la microservei ha de cachejar el resultat.

## Per què les decisions

La motivació completa de cada decisió (per què *quota-balanced* enlloc de iid uniforme, per què scipy enlloc de *choix* a producció, per què bootstrap amb etiquetes fixes, etc.) és a [`docs/T7_ranking_design.md`](docs/T7_ranking_design.md), incloent una crítica externa de ChatGPT Pro i les correccions que en van sortir.

Destacables:
- Trio *quota-balanced* per defecte; iid uniforme generaria variància Poisson entre cel·les (cel·les amb el doble de vots que altres) i defensaria malament la validació de clustering.
- L'ajust BT és nostre (~30 línies amb `scipy.optimize`); *choix* es manté com a dependència de dev per validació creuada del nostre fit contra una implementació de referència.
- El bootstrap *amb etiquetes fixes* va corregir un bug que tenia la primera versió (gap forçat a ser ≥ 0 perquè s'ordenava dins de cada replica → declarava estables rànquings inestables).

## Què NO fa aquesta biblioteca

- No defineix els *endpoints* de FastAPI (això és la #6, Isaac).
- No genera el *token* HMAC del vot (#6).
- No grava els vots a la base de dades (#6).
- No gestiona el cache de `/api/ranking` (#6).
- No implementa el sampler basat en uncertainty (regla de Chiang et al.); l'experiment a `analysis/phase1/04_samplers_comparison.py` indica que no aporta a n=3, però es pot afegir més endavant com a estratègia alternativa quan la flota de models creixi.

## Pla de proves

- **Tests unitaris purament matemàtics** per `fit_bt` cobreixen entrada buida, guanyador clar i separació completa. Passats en local.
- **Tests d'integració** per `compute_ranking`, `assess_confidence` i `select_next_task` fan servir el fixture `session` ja existent al `conftest.py`. S'executaran a CI contra `arena_cat_test`.

## Dependències

Afegeixo a `pyproject.toml`:
- `numpy>=1.26` i `scipy>=1.11` com a *runtime* (per l'ajust BT i el bootstrap).
- `choix>=0.3` com a *dev* (només per validar el nostre ajust contra la referència en tests).

## Notes de revisió

- Branch rebasada sobre `main` (commit `39bd981`).
- `ruff check` i `ruff format` netes.
- Convencions de l'`AGENTS.md` respectades: identificadors en anglès, docstrings i comentaris en català.
- Cap canvi al model de dades existent.

Qualsevol decisió us sembla discutible, m'agradaria saber-ho — especialment la tria de *quota-balanced* enlloc del que demana literalment `pla_detallat.md` (*"tria un prompt aleatori"*); ho explico al doc de disseny i ho pot fer marxa enrere amb una línia.