### PR TITLE
feat(scripts): càrrega idempotent d'inferències a la base de dades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# Comandes de desenvolupament d'Arena Cat. Executa-les des de l'arrel del repositori.
+
+.PHONY: load_inferences
+
+# Carrega els prompts i les inferències versionats a la base de dades.
+# Per defecte usa data/prompts/v1 i data/inferencies/v1. Es poden sobreescriure
+# amb variables d'entorn:
+#   make load_inferences
+#   PROMPTS_DIR=data/prompts/v2 INFERENCIES_DIR=data/inferencies/v2 make load_inferences
+load_inferences:
+	uv --project backend run python scripts/carrega_inferencies.py \
+		$(if $(PROMPTS_DIR),--prompts-dir $(PROMPTS_DIR)) \
+		$(if $(INFERENCIES_DIR),--inferencies-dir $(INFERENCIES_DIR)) \
+		$(if $(VERSION),--version $(VERSION))

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ Un cop validada la mecànica amb la prova de concepte, ampliarem l'abast incorpo
                     <sub><b>bytesontherocks</b></sub>
                 </a>
             </td>
+            <td align="center">
+                <a href="https://github.com/estevecastells">
+                    <img src="https://avatars.githubusercontent.com/u/14035230?v=4" width="100;" alt="estevecastells"/>
+                    <br />
+                    <sub><b>Esteve Castells</b></sub>
+                </a>
+            </td>
 		</tr>
 	<tbody>
 </table>

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "alembic>=1.13",
     "psycopg[binary]>=3.1",
     "pydantic-settings>=2.0",
+    "pyyaml>=6.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_carrega_inferencies.py
+++ b/backend/tests/test_carrega_inferencies.py
@@ -1,0 +1,215 @@
+"""Tests de la càrrega idempotent de prompts i inferències (contra PostgreSQL real)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+from sqlalchemy import func, select
+
+from app.models import Prompt, Response
+
+# L'script viu a scripts/ (projecte arrel), fora del paquet backend.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+import carrega_inferencies as loader  # noqa: E402
+
+
+def write_prompt(prompts_dir: Path, code: str, text: str = "Tradueix aquest text.") -> None:
+    """Escriu un prompt en el format escalar de text que usa la canonada."""
+    prompts_dir.mkdir(parents=True, exist_ok=True)
+    (prompts_dir / f"{code}.yaml").write_text(text, encoding="utf-8")
+
+
+def write_inference(
+    inferencies_dir: Path,
+    model_id: str,
+    prompt_code: str,
+    answer: str = "Una resposta.",
+    reasoning: str | None = None,
+) -> None:
+    """Escriu una inferència imitant la sortida de scripts/inferencia.py."""
+    model_dir = inferencies_dir / model_id
+    model_dir.mkdir(parents=True, exist_ok=True)
+    document = {
+        "run": {"timestamp": "2026-01-01T00:00:00Z", "git_commit": "abc123", "seed": 42},
+        "prompt": {
+            "id": prompt_code,
+            "path": f"data/prompts/v1/{prompt_code}.yaml",
+            "sha256": "deadbeef",
+        },
+        "model": {"id": model_id, "model_name": f"org/{model_id}", "revision": "main"},
+        "generation": {"temperature": 0.7, "top_p": 0.9, "max_new_tokens": 1024, "seed": 42},
+        "backend": {"engine": "transformers", "transformers_version": "5", "torch_version": "2"},
+        "output": {"answer": answer},
+        "reasoning": {"content": reasoning},
+    }
+    (model_dir / f"{prompt_code}.yaml").write_text(
+        yaml.dump(document, allow_unicode=True), encoding="utf-8"
+    )
+
+
+@pytest.fixture
+def dirs(tmp_path):
+    """Directoris buits de prompts i inferències per a la versió v1."""
+    prompts_dir = tmp_path / "prompts" / "v1"
+    inferencies_dir = tmp_path / "inferencies" / "v1"
+    prompts_dir.mkdir(parents=True)
+    inferencies_dir.mkdir(parents=True)
+    return prompts_dir, inferencies_dir
+
+
+def _count(session, model) -> int:
+    return session.scalar(select(func.count()).select_from(model))
+
+
+def test_prompt_is_inserted_with_derived_category(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "traduccio_1", "Tradueix això.")
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.prompts.inserted == 1
+    assert summary.prompts.errors == 0
+    prompt = session.scalar(select(Prompt).where(Prompt.code == "traduccio_1"))
+    assert prompt.version == "v1"
+    assert prompt.text == "Tradueix això."
+    assert prompt.category.code == "traduccio"
+
+
+def test_load_is_idempotent(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "correccio_1")
+    write_inference(inferencies_dir, "qwen-3.5-9b", "correccio_1")
+
+    first = loader.run_load(session, prompts_dir, inferencies_dir)
+    assert (first.prompts.inserted, first.responses.inserted) == (1, 1)
+
+    second = loader.run_load(session, prompts_dir, inferencies_dir)
+    assert second.prompts.skipped == 1
+    assert second.responses.skipped == 1
+    assert second.prompts.inserted == 0
+    assert second.responses.inserted == 0
+
+    # Cap duplicat.
+    assert _count(session, Prompt) == 1
+    assert _count(session, Response) == 1
+
+
+def test_responses_link_to_prompt_by_version_and_code(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "reformulacio_1")
+    write_inference(inferencies_dir, "qwen-3.5-9b", "reformulacio_1", answer="Resposta A")
+    write_inference(
+        inferencies_dir, "salamandra-7b-instruct", "reformulacio_1", answer="Resposta B"
+    )
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.responses.inserted == 2
+    assert summary.responses.errors == 0
+    prompt = session.scalar(select(Prompt).where(Prompt.code == "reformulacio_1"))
+    responses = session.scalars(
+        select(Response).where(Response.prompt_id == prompt.id).order_by(Response.model)
+    ).all()
+    assert [r.model for r in responses] == ["qwen-3.5-9b", "salamandra-7b-instruct"]
+    assert {r.text for r in responses} == {"Resposta A", "Resposta B"}
+    assert responses[0].inference_metadata["model_name"] == "org/qwen-3.5-9b"
+    assert responses[0].inference_metadata["generation"]["temperature"] == 0.7
+
+
+def test_reasoning_goes_to_metadata_not_visible_text(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "traduccio_1")
+    write_inference(
+        inferencies_dir,
+        "qwen-3.5-9b",
+        "traduccio_1",
+        answer="Resposta final",
+        reasoning="Raonament intern del model",
+    )
+
+    loader.run_load(session, prompts_dir, inferencies_dir)
+
+    response = session.scalar(select(Response))
+    assert response.text == "Resposta final"
+    assert "Raonament" not in response.text
+    assert response.inference_metadata["reasoning"] == "Raonament intern del model"
+
+
+def test_changed_answer_triggers_update(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "traduccio_1")
+    write_inference(inferencies_dir, "qwen-3.5-9b", "traduccio_1", answer="Primera")
+    loader.run_load(session, prompts_dir, inferencies_dir)
+
+    write_inference(inferencies_dir, "qwen-3.5-9b", "traduccio_1", answer="Segona")
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.responses.updated == 1
+    assert summary.responses.inserted == 0
+    response = session.scalar(select(Response))
+    assert response.text == "Segona"
+    assert _count(session, Response) == 1
+
+
+def test_unknown_prompt_in_inference_is_error(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    # Cap prompt traduccio_99 a la base de dades.
+    write_inference(inferencies_dir, "qwen-3.5-9b", "traduccio_99")
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.responses.errors == 1
+    assert summary.responses.inserted == 0
+    assert _count(session, Response) == 0
+
+
+def test_unknown_category_is_error(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "inexistent_1")
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.prompts.errors == 1
+    assert summary.prompts.inserted == 0
+    assert _count(session, Prompt) == 0
+
+
+def test_missing_required_field_is_error(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "traduccio_1")
+    # Inferència sense output.answer.
+    model_dir = inferencies_dir / "qwen-3.5-9b"
+    model_dir.mkdir(parents=True)
+    (model_dir / "traduccio_1.yaml").write_text(
+        yaml.dump({"prompt": {"id": "traduccio_1"}, "model": {"id": "qwen-3.5-9b"}}),
+        encoding="utf-8",
+    )
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.responses.errors == 1
+    assert summary.responses.inserted == 0
+
+
+def test_malformed_yaml_is_counted_and_others_load(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "traduccio_1")
+    (prompts_dir / "trencat.yaml").write_text("text: [sense tancar", encoding="utf-8")
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.prompts.inserted == 1
+    assert summary.prompts.errors == 1
+    assert _count(session, Prompt) == 1
+
+
+def test_summary_total_errors_drives_exit_code(session, dirs):
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "traduccio_1")
+    write_inference(inferencies_dir, "qwen-3.5-9b", "traduccio_99")
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.total_errors == 1

--- a/backend/tests/test_carrega_inferencies.py
+++ b/backend/tests/test_carrega_inferencies.py
@@ -77,6 +77,27 @@ def test_prompt_is_inserted_with_derived_category(session, dirs):
     assert prompt.category.code == "traduccio"
 
 
+def test_prompt_list_file_loads_each_entry(session, dirs):
+    # Un sol fitxer amb una llista de prompts (format compartit amb inferencia.py).
+    prompts_dir, inferencies_dir = dirs
+    (prompts_dir / "llista.yaml").write_text(
+        yaml.dump(
+            [
+                {"id": "traduccio_1", "text": "Prompt A"},
+                {"id": "traduccio_2", "text": "Prompt B"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.prompts.inserted == 2
+    assert summary.prompts.errors == 0
+    codes = session.scalars(select(Prompt.code).order_by(Prompt.code)).all()
+    assert codes == ["traduccio_1", "traduccio_2"]
+
+
 def test_load_is_idempotent(session, dirs):
     prompts_dir, inferencies_dir = dirs
     write_prompt(prompts_dir, "correccio_1")
@@ -137,7 +158,9 @@ def test_reasoning_goes_to_metadata_not_visible_text(session, dirs):
     assert response.inference_metadata["reasoning"] == "Raonament intern del model"
 
 
-def test_changed_answer_triggers_update(session, dirs):
+def test_changed_answer_is_conflict_error_and_keeps_original(session, dirs):
+    # Tornar a carregar una resposta amb un text diferent no l'ha de sobreescriure:
+    # els vots existents hi apunten. És un error que exigeix una versió nova.
     prompts_dir, inferencies_dir = dirs
     write_prompt(prompts_dir, "traduccio_1")
     write_inference(inferencies_dir, "qwen-3.5-9b", "traduccio_1", answer="Primera")
@@ -146,11 +169,29 @@ def test_changed_answer_triggers_update(session, dirs):
     write_inference(inferencies_dir, "qwen-3.5-9b", "traduccio_1", answer="Segona")
     summary = loader.run_load(session, prompts_dir, inferencies_dir)
 
-    assert summary.responses.updated == 1
+    assert summary.responses.errors == 1
     assert summary.responses.inserted == 0
+    assert summary.responses.skipped == 0
     response = session.scalar(select(Response))
-    assert response.text == "Segona"
+    assert response.text == "Primera"  # intacta
     assert _count(session, Response) == 1
+
+
+def test_changed_prompt_text_is_conflict_error_and_keeps_original(session, dirs):
+    # El mateix s'aplica als prompts: un canvi de text amb la mateixa clau falla.
+    prompts_dir, inferencies_dir = dirs
+    write_prompt(prompts_dir, "traduccio_1", "Tradueix això.")
+    loader.run_load(session, prompts_dir, inferencies_dir)
+
+    write_prompt(prompts_dir, "traduccio_1", "Tradueix una altra cosa.")
+    summary = loader.run_load(session, prompts_dir, inferencies_dir)
+
+    assert summary.prompts.errors == 1
+    assert summary.prompts.inserted == 0
+    assert summary.prompts.skipped == 0
+    prompt = session.scalar(select(Prompt).where(Prompt.code == "traduccio_1"))
+    assert prompt.text == "Tradueix això."  # intacte
+    assert _count(session, Prompt) == 1
 
 
 def test_unknown_prompt_in_inference_is_error(session, dirs):

--- a/backend/tests/test_carrega_inferencies.py
+++ b/backend/tests/test_carrega_inferencies.py
@@ -98,6 +98,18 @@ def test_prompt_list_file_loads_each_entry(session, dirs):
     assert codes == ["traduccio_1", "traduccio_2"]
 
 
+def test_prompts_load_in_natural_order(session, dirs):
+    # traduccio_10 s'ha d'inserir després de traduccio_2, no entre l'1 i el 2.
+    prompts_dir, inferencies_dir = dirs
+    for code in ("traduccio_1", "traduccio_2", "traduccio_10"):
+        write_prompt(prompts_dir, code)
+
+    loader.run_load(session, prompts_dir, inferencies_dir)
+
+    codes_by_id = session.scalars(select(Prompt.code).order_by(Prompt.id)).all()
+    assert codes_by_id == ["traduccio_1", "traduccio_2", "traduccio_10"]
+
+
 def test_load_is_idempotent(session, dirs):
     prompts_dir, inferencies_dir = dirs
     write_prompt(prompts_dir, "correccio_1")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -33,6 +33,7 @@ dependencies = [
     { name = "alembic" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic-settings" },
+    { name = "pyyaml" },
     { name = "sqlalchemy" },
 ]
 
@@ -48,6 +49,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", specifier = ">=2.0" },
 ]
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -120,19 +120,18 @@ Aquesta configuració fa servir `hf-internal-testing/tiny-random-gpt2`, un model
 
 `scripts/carrega_inferencies.py` publica els fitxers versionats a les taules `prompts` i `responses`. Llegeix els prompts de `data/prompts/v1/*.yaml` (clau `(version, code)`, on `code` és el nom del fitxer i la categoria es dedueix del prefix, p. ex. `traduccio_1` -> `traduccio`) i les inferències de `data/inferencies/v1/<model_id>/*.yaml` (clau `(prompt_id, model)`). El raonament intern es desa a les metadades, no al text visible, perquè l'avaluació és a cegues.
 
-És **idempotent**: tornar-lo a executar no duplica files. Cada fila es classifica com a inserida, actualitzada o omesa (sense canvis), i n'imprimeix un resum a la sortida estàndard. Si un fitxer no compleix l'esquema (categoria o prompt desconegut, camps obligatoris absents, YAML mal format), registra un error clar i acaba amb codi de sortida 1 sense aturar la resta de la càrrega.
+És **idempotent**: tornar-lo a executar no duplica files. Cada fila es classifica com a inserida o omesa (ja existeix amb el mateix contingut), i n'imprimeix un resum a la sortida estàndard. **No modifica files existents**: si un prompt o una resposta ja existeix amb la mateixa clau però amb un contingut diferent, ho registra com a error i exigeix publicar-ho amb una versió nova en comptes de sobreescriure-ho. Sobreescriure el text d'una resposta invalidaria semànticament els vots que hi apunten (mantenen el `response_id` però votaven un text que hauria canviat). Igualment, si un fitxer no compleix l'esquema (categoria o prompt desconegut, camps obligatoris absents, YAML mal format), registra un error clar. En tots els casos d'error acaba amb codi de sortida 1 sense aturar la resta de la càrrega.
 
-Necessita la base de dades en marxa i migrada, i les mateixes variables de connexió que el backend (vegeu `.env`). S'executa des de `backend/` perquè en reaprofita l'entorn i el model de dades:
+Necessita la base de dades en marxa i migrada, i les mateixes variables de connexió que el backend (vegeu `.env`). Reaprofita l'entorn i el model de dades del backend, així que s'executa amb `--project backend` des de l'arrel del repositori:
 
 ```bash
-cd backend
-uv run python ../scripts/carrega_inferencies.py
+uv --project backend run python scripts/carrega_inferencies.py
 ```
 
 Per defecte usa `data/prompts/v1` i `data/inferencies/v1`. Es poden sobreescriure els directoris i la versió:
 
 ```bash
-uv run python ../scripts/carrega_inferencies.py \
-    --prompts-dir ../data/prompts/v1 \
-    --inferencies-dir ../data/inferencies/v1
+uv --project backend run python scripts/carrega_inferencies.py \
+    --prompts-dir data/prompts/v1 \
+    --inferencies-dir data/inferencies/v1
 ```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -122,13 +122,19 @@ Aquesta configuració fa servir `hf-internal-testing/tiny-random-gpt2`, un model
 
 És **idempotent**: tornar-lo a executar no duplica files. Cada fila es classifica com a inserida o omesa (ja existeix amb el mateix contingut), i n'imprimeix un resum a la sortida estàndard. **No modifica files existents**: si un prompt o una resposta ja existeix amb la mateixa clau però amb un contingut diferent, ho registra com a error i exigeix publicar-ho amb una versió nova en comptes de sobreescriure-ho. Sobreescriure el text d'una resposta invalidaria semànticament els vots que hi apunten (mantenen el `response_id` però votaven un text que hauria canviat). Igualment, si un fitxer no compleix l'esquema (categoria o prompt desconegut, camps obligatoris absents, YAML mal format), registra un error clar. En tots els casos d'error acaba amb codi de sortida 1 sense aturar la resta de la càrrega.
 
-Necessita la base de dades en marxa i migrada, i les mateixes variables de connexió que el backend (vegeu `.env`). Reaprofita l'entorn i el model de dades del backend, així que s'executa amb `--project backend` des de l'arrel del repositori:
+Necessita la base de dades en marxa i migrada, i les mateixes variables de connexió que el backend (vegeu `.env`). La manera més curta és el target del `Makefile`, des de l'arrel del repositori:
 
 ```bash
-uv --project backend run python scripts/carrega_inferencies.py
+make load_inferences
 ```
 
-Per defecte usa `data/prompts/v1` i `data/inferencies/v1`. Es poden sobreescriure els directoris i la versió:
+Per defecte usa `data/prompts/v1` i `data/inferencies/v1`. Es poden sobreescriure els directoris i la versió amb variables d'entorn:
+
+```bash
+PROMPTS_DIR=data/prompts/v2 INFERENCIES_DIR=data/inferencies/v2 make load_inferences
+```
+
+El target només és un embolcall d'aquesta comanda, que reaprofita l'entorn i el model de dades del backend amb `--project backend` i també es pot cridar directament:
 
 ```bash
 uv --project backend run python scripts/carrega_inferencies.py \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -115,3 +115,24 @@ uv run python scripts/inferencia.py --config config/inferencia/inferencia_local_
 ```
 
 Aquesta configuració fa servir `hf-internal-testing/tiny-random-gpt2`, un model de prova molt petit. Serveix per validar que la descàrrega, la càrrega del model, la generació i l'escriptura dels YAML funcionen, però no per avaluar qualitat lingüística.
+
+### 8. Carregar prompts i inferències a la base de dades
+
+`scripts/carrega_inferencies.py` publica els fitxers versionats a les taules `prompts` i `responses`. Llegeix els prompts de `data/prompts/v1/*.yaml` (clau `(version, code)`, on `code` és el nom del fitxer i la categoria es dedueix del prefix, p. ex. `traduccio_1` -> `traduccio`) i les inferències de `data/inferencies/v1/<model_id>/*.yaml` (clau `(prompt_id, model)`). El raonament intern es desa a les metadades, no al text visible, perquè l'avaluació és a cegues.
+
+És **idempotent**: tornar-lo a executar no duplica files. Cada fila es classifica com a inserida, actualitzada o omesa (sense canvis), i n'imprimeix un resum a la sortida estàndard. Si un fitxer no compleix l'esquema (categoria o prompt desconegut, camps obligatoris absents, YAML mal format), registra un error clar i acaba amb codi de sortida 1 sense aturar la resta de la càrrega.
+
+Necessita la base de dades en marxa i migrada, i les mateixes variables de connexió que el backend (vegeu `.env`). S'executa des de `backend/` perquè en reaprofita l'entorn i el model de dades:
+
+```bash
+cd backend
+uv run python ../scripts/carrega_inferencies.py
+```
+
+Per defecte usa `data/prompts/v1` i `data/inferencies/v1`. Es poden sobreescriure els directoris i la versió:
+
+```bash
+uv run python ../scripts/carrega_inferencies.py \
+    --prompts-dir ../data/prompts/v1 \
+    --inferencies-dir ../data/inferencies/v1
+```

--- a/scripts/carrega_inferencies.py
+++ b/scripts/carrega_inferencies.py
@@ -1,18 +1,464 @@
-# Script idempotent d'upsert a la base de dades
+"""Càrrega idempotent de prompts i inferències a la base de dades.
+
+Llegeix els prompts versionats a ``data/prompts/<version>/*.yaml`` i les
+inferències a ``data/inferencies/<version>/<model_id>/*.yaml``, i en fa *upsert*
+a les taules ``prompts`` i ``responses``. La clau natural d'un prompt és
+``(version, code)`` i la d'una resposta ``(prompt_id, model)``, de manera que
+tornar a executar l'script no duplica files ni en trenca les restriccions.
+
+La connexió es resol amb la mateixa configuració que el servei (``app.config``),
+és a dir el rol d'aplicació amb permisos limitats.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import yaml
 
-# Dins de scripts/carrega_inferencies.py, canviar la secció de lectura a:
-inferencies_files = Path("data/inferencies/v1").rglob("*.yaml")
-for file_path in inferencies_files:
-    with file_path.open("r", encoding="utf-8") as f:
-        inf = yaml.safe_load(f)
+REPO_ROOT = Path(__file__).resolve().parents[1]
+# El model de dades i la configuració viuen al paquet backend/app.
+sys.path.insert(0, str(REPO_ROOT / "backend"))
 
-    prompt_id = inf["prompt"]["id"]
-    model_id = inf["model"]["id"]
+from sqlalchemy import select  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
 
-    # El text final separat va a la base de dades
-    text_resposta = inf["output"]["answer"]
-    # El contingut del raonament s'emmagatzema o es deixa en blanc per a l'avaluació cega
-    # ... executa l'upsert tal com s'havia dissenyat a la taula `respostes` ...
+from app.db import get_sessionmaker  # noqa: E402
+from app.models import Category, Prompt, Response  # noqa: E402
+
+LOGGER = logging.getLogger("carrega_inferencies")
+
+DEFAULT_VERSION = "v1"
+DEFAULT_PROMPTS_DIR = REPO_ROOT / "data" / "prompts" / DEFAULT_VERSION
+DEFAULT_INFERENCIES_DIR = REPO_ROOT / "data" / "inferencies" / DEFAULT_VERSION
+
+# El codi d'un prompt acaba amb un sufix numèric (p. ex. ``traduccio_10``); la
+# resta identifica la categoria (``traduccio``).
+_CODE_SUFFIX = re.compile(r"_\d+$")
+
+
+class SchemaError(Exception):
+    """Un fitxer YAML no compleix l'esquema esperat.
+
+    Es fa servir per a camps obligatoris absents, tipus inesperats o referències
+    a entitats desconegudes (categoria o prompt).
+    """
+
+
+@dataclass
+class PromptRecord:
+    """Prompt normalitzat, a punt per fer *upsert* a la taula ``prompts``."""
+
+    version: str
+    code: str
+    category_code: str
+    text: str
+    source: Path
+
+
+@dataclass
+class ResponseRecord:
+    """Resposta d'un model normalitzada, per fer *upsert* a ``responses``."""
+
+    version: str
+    prompt_code: str
+    model: str
+    text: str
+    metadata: dict[str, Any]
+    source: Path
+
+
+@dataclass
+class Stats:
+    """Recompte d'un tipus d'entitat carregada."""
+
+    inserted: int = 0
+    updated: int = 0
+    skipped: int = 0
+    errors: int = 0
+
+
+@dataclass
+class Summary:
+    """Resum global de la càrrega."""
+
+    prompts: Stats
+    responses: Stats
+
+    @property
+    def total_errors(self) -> int:
+        return self.prompts.errors + self.responses.errors
+
+
+def _require(value: Any, message: str, source: Path) -> Any:
+    """Comprova que un camp obligatori hi és i no és buit.
+
+    Args:
+        value: Valor llegit del YAML.
+        message: Descripció de l'incompliment per al missatge d'error.
+        source: Fitxer d'origen, per situar l'error.
+
+    Returns:
+        El valor original si és vàlid.
+
+    Raises:
+        SchemaError: Si el valor és ``None`` o una cadena buida.
+    """
+    if value is None or (isinstance(value, str) and not value.strip()):
+        raise SchemaError(f"{source}: {message}")
+    return value
+
+
+def _nested(data: Any, *keys: str) -> Any:
+    """Accedeix a una clau imbricada sense petar si falta un nivell.
+
+    Args:
+        data: Estructura carregada del YAML.
+        *keys: Seqüència de claus a recórrer.
+
+    Returns:
+        El valor trobat, o ``None`` si qualsevol nivell no és un mapa o no hi és.
+    """
+    current = data
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def category_code_for(code: str) -> str:
+    """Deriva el codi de categoria a partir del codi de prompt.
+
+    Args:
+        code: Codi del prompt (p. ex. ``traduccio_10``).
+
+    Returns:
+        Codi de categoria (p. ex. ``traduccio``).
+    """
+    return _CODE_SUFFIX.sub("", code)
+
+
+def parse_prompt_file(path: Path, version: str) -> PromptRecord:
+    """Llegeix un fitxer de prompt i el normalitza.
+
+    Accepta tant un escalar de text (el cos del prompt) com un mapa amb els camps
+    ``code``/``id``, ``text`` i, opcionalment, ``category``.
+
+    Args:
+        path: Fitxer YAML del prompt.
+        version: Versió del conjunt de dades.
+
+    Returns:
+        Prompt normalitzat.
+
+    Raises:
+        SchemaError: Si el contingut no és text ni mapa, o no té text.
+    """
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    if isinstance(data, str):
+        code = path.stem
+        text = data
+        category_code = category_code_for(code)
+    elif isinstance(data, dict):
+        code = str(data.get("code") or data.get("id") or path.stem)
+        text = data.get("text")
+        category_code = str(data.get("category") or category_code_for(code))
+    else:
+        raise SchemaError(f"{path}: el prompt ha de ser un text o un mapa")
+
+    text = _require(text, "el prompt no té text", path)
+    return PromptRecord(
+        version=version,
+        code=code,
+        category_code=category_code,
+        text=text.strip(),
+        source=path,
+    )
+
+
+def parse_inference_file(path: Path, version: str) -> ResponseRecord:
+    """Llegeix un fitxer d'inferència i el normalitza.
+
+    Args:
+        path: Fitxer YAML d'inferència (sortida de la canonada).
+        version: Versió del conjunt de dades.
+
+    Returns:
+        Resposta normalitzada. El raonament intern es desa a les metadades, no al
+        text visible, perquè l'avaluació és a cegues.
+
+    Raises:
+        SchemaError: Si no és un mapa o falta ``prompt.id``, ``model.id`` o
+            ``output.answer``.
+    """
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise SchemaError(f"{path}: la inferència ha de ser un mapa")
+
+    prompt_code = _require(_nested(data, "prompt", "id"), "falta prompt.id", path)
+    model = _require(_nested(data, "model", "id"), "falta model.id", path)
+    answer = _require(_nested(data, "output", "answer"), "falta output.answer", path)
+
+    metadata = {
+        "model_name": _nested(data, "model", "model_name"),
+        "revision": _nested(data, "model", "revision"),
+        "generation": data.get("generation"),
+        "run": data.get("run"),
+        "backend": data.get("backend"),
+        "prompt_sha256": _nested(data, "prompt", "sha256"),
+        "reasoning": _nested(data, "reasoning", "content"),
+    }
+    metadata = {key: value for key, value in metadata.items() if value is not None}
+
+    return ResponseRecord(
+        version=version,
+        prompt_code=str(prompt_code),
+        model=str(model),
+        text=str(answer).strip(),
+        metadata=metadata,
+        source=path,
+    )
+
+
+def upsert_prompt(
+    session: Session,
+    record: PromptRecord,
+    category_ids: dict[str, int],
+    stats: Stats,
+) -> None:
+    """Fa *upsert* d'un prompt per la clau ``(version, code)``.
+
+    Args:
+        session: Sessió de base de dades activa.
+        record: Prompt normalitzat.
+        category_ids: Mapa de codi de categoria a identificador.
+        stats: Recompte que s'actualitza segons el resultat.
+    """
+    category_id = category_ids.get(record.category_code)
+    if category_id is None:
+        LOGGER.error("%s: categoria desconeguda '%s'", record.source, record.category_code)
+        stats.errors += 1
+        return
+
+    existing = session.scalar(
+        select(Prompt).where(Prompt.version == record.version, Prompt.code == record.code)
+    )
+    if existing is None:
+        session.add(
+            Prompt(
+                version=record.version,
+                code=record.code,
+                category_id=category_id,
+                text=record.text,
+            )
+        )
+        session.flush()
+        stats.inserted += 1
+    elif existing.text != record.text or existing.category_id != category_id:
+        existing.text = record.text
+        existing.category_id = category_id
+        session.flush()
+        stats.updated += 1
+    else:
+        stats.skipped += 1
+
+
+def upsert_response(session: Session, record: ResponseRecord, stats: Stats) -> None:
+    """Fa *upsert* d'una resposta per la clau ``(prompt_id, model)``.
+
+    Args:
+        session: Sessió de base de dades activa.
+        record: Resposta normalitzada.
+        stats: Recompte que s'actualitza segons el resultat.
+    """
+    prompt = session.scalar(
+        select(Prompt).where(Prompt.version == record.version, Prompt.code == record.prompt_code)
+    )
+    if prompt is None:
+        LOGGER.error(
+            "%s: prompt desconegut (%s/%s)", record.source, record.version, record.prompt_code
+        )
+        stats.errors += 1
+        return
+
+    existing = session.scalar(
+        select(Response).where(Response.prompt_id == prompt.id, Response.model == record.model)
+    )
+    if existing is None:
+        session.add(
+            Response(
+                prompt_id=prompt.id,
+                model=record.model,
+                text=record.text,
+                inference_metadata=record.metadata,
+            )
+        )
+        session.flush()
+        stats.inserted += 1
+    elif existing.text != record.text or existing.inference_metadata != record.metadata:
+        existing.text = record.text
+        existing.inference_metadata = record.metadata
+        session.flush()
+        stats.updated += 1
+    else:
+        stats.skipped += 1
+
+
+def load_prompts(
+    session: Session,
+    prompts_dir: Path,
+    version: str,
+    category_ids: dict[str, int],
+    stats: Stats,
+) -> None:
+    """Carrega tots els prompts d'un directori.
+
+    Args:
+        session: Sessió de base de dades activa.
+        prompts_dir: Directori amb els fitxers de prompt.
+        version: Versió del conjunt de dades.
+        category_ids: Mapa de codi de categoria a identificador.
+        stats: Recompte que s'actualitza.
+    """
+    for path in sorted(prompts_dir.glob("*.yaml")):
+        try:
+            record = parse_prompt_file(path, version)
+        except (SchemaError, yaml.YAMLError) as error:
+            LOGGER.error("prompt no vàlid: %s", error)
+            stats.errors += 1
+            continue
+        upsert_prompt(session, record, category_ids, stats)
+
+
+def load_responses(session: Session, inferencies_dir: Path, version: str, stats: Stats) -> None:
+    """Carrega totes les inferències d'un directori (recursivament).
+
+    Args:
+        session: Sessió de base de dades activa.
+        inferencies_dir: Directori arrel de les inferències.
+        version: Versió del conjunt de dades.
+        stats: Recompte que s'actualitza.
+    """
+    for path in sorted(inferencies_dir.rglob("*.yaml")):
+        try:
+            record = parse_inference_file(path, version)
+        except (SchemaError, yaml.YAMLError) as error:
+            LOGGER.error("inferència no vàlida: %s", error)
+            stats.errors += 1
+            continue
+        upsert_response(session, record, stats)
+
+
+def run_load(
+    session: Session,
+    prompts_dir: Path | str,
+    inferencies_dir: Path | str,
+    version: str | None = None,
+) -> Summary:
+    """Carrega prompts i inferències dins de la sessió donada.
+
+    No fa ``commit``: és responsabilitat de qui crida la funció (la CLI confirma
+    la transacció; els tests la desfan).
+
+    Args:
+        session: Sessió de base de dades activa.
+        prompts_dir: Directori dels prompts.
+        inferencies_dir: Directori arrel de les inferències.
+        version: Versió del conjunt de dades. Si és ``None``, es dedueix del nom
+            del directori de prompts (p. ex. ``data/prompts/v1`` -> ``v1``).
+
+    Returns:
+        Resum amb els recomptes de prompts i respostes.
+    """
+    prompts_dir = Path(prompts_dir)
+    inferencies_dir = Path(inferencies_dir)
+    version = version or prompts_dir.name
+
+    category_ids = {category.code: category.id for category in session.scalars(select(Category))}
+
+    summary = Summary(prompts=Stats(), responses=Stats())
+    load_prompts(session, prompts_dir, version, category_ids, summary.prompts)
+    load_responses(session, inferencies_dir, version, summary.responses)
+    return summary
+
+
+def _format_stats(stats: Stats) -> str:
+    return (
+        f"inserits={stats.inserted} actualitzats={stats.updated} "
+        f"omesos={stats.skipped} errors={stats.errors}"
+    )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Llegeix els paràmetres CLI.
+
+    Args:
+        argv: Arguments alternatius (per a tests); ``None`` usa ``sys.argv``.
+
+    Returns:
+        Namespace amb els paràmetres.
+    """
+    parser = argparse.ArgumentParser(
+        description="Càrrega idempotent de prompts i inferències a la base de dades.",
+    )
+    parser.add_argument(
+        "--prompts-dir",
+        type=Path,
+        default=DEFAULT_PROMPTS_DIR,
+        help="Directori amb els fitxers YAML de prompts.",
+    )
+    parser.add_argument(
+        "--inferencies-dir",
+        type=Path,
+        default=DEFAULT_INFERENCIES_DIR,
+        help="Directori arrel amb les inferències (un subdirectori per model).",
+    )
+    parser.add_argument(
+        "--version",
+        default=None,
+        help="Versió del conjunt de dades. Per defecte, el nom del directori de prompts.",
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=("DEBUG", "INFO", "WARNING", "ERROR"),
+        default="INFO",
+        help="Nivell mínim dels missatges de logging.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Punt d'entrada CLI.
+
+    Args:
+        argv: Arguments alternatius (per a tests); ``None`` usa ``sys.argv``.
+
+    Returns:
+        ``0`` si tot ha anat bé, ``1`` si algun fitxer no complia l'esquema.
+    """
+    args = parse_args(argv)
+    logging.basicConfig(level=args.log_level, format="%(levelname)s:%(name)s:%(message)s")
+
+    with get_sessionmaker()() as session:
+        summary = run_load(session, args.prompts_dir, args.inferencies_dir, args.version)
+        session.commit()
+
+    print(f"Prompts:   {_format_stats(summary.prompts)}")
+    print(f"Respostes: {_format_stats(summary.responses)}")
+
+    if summary.total_errors:
+        LOGGER.error("S'han trobat %s fitxers no vàlids.", summary.total_errors)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/carrega_inferencies.py
+++ b/scripts/carrega_inferencies.py
@@ -52,7 +52,7 @@ class SchemaError(Exception):
     """
 
 
-@dataclass
+@dataclass(slots=True)
 class PromptRecord:
     """Prompt normalitzat, a punt per fer *upsert* a la taula ``prompts``."""
 
@@ -63,7 +63,7 @@ class PromptRecord:
     source: Path
 
 
-@dataclass
+@dataclass(slots=True)
 class ResponseRecord:
     """Resposta d'un model normalitzada, per fer *upsert* a ``responses``."""
 
@@ -75,7 +75,7 @@ class ResponseRecord:
     source: Path
 
 
-@dataclass
+@dataclass(slots=True)
 class Stats:
     """Recompte d'un tipus d'entitat carregada.
 
@@ -90,7 +90,7 @@ class Stats:
     errors: int = 0
 
 
-@dataclass
+@dataclass(slots=True)
 class Summary:
     """Resum global de la càrrega."""
 
@@ -139,18 +139,6 @@ def _nested(data: Any, *keys: str) -> Any:
     return current
 
 
-def category_code_for(code: str) -> str:
-    """Deriva el codi de categoria a partir del codi de prompt.
-
-    Args:
-        code: Codi del prompt (p. ex. ``traduccio_10``).
-
-    Returns:
-        Codi de categoria (p. ex. ``traduccio``).
-    """
-    return _CODE_SUFFIX.sub("", code)
-
-
 def parse_prompt_file(path: Path, version: str) -> list[PromptRecord]:
     """Llegeix un fitxer de prompt i en normalitza les entrades.
 
@@ -180,7 +168,7 @@ def parse_prompt_file(path: Path, version: str) -> list[PromptRecord]:
     for entry in entries:
         code = str(entry.get("code") or entry.get("id") or path.stem)
         text = _require(entry.get("text"), "el prompt no té text", path)
-        category_code = str(entry.get("category") or category_code_for(code))
+        category_code = str(entry.get("category") or _CODE_SUFFIX.sub("", code))
         records.append(
             PromptRecord(
                 version=version,

--- a/scripts/carrega_inferencies.py
+++ b/scripts/carrega_inferencies.py
@@ -43,6 +43,26 @@ DEFAULT_INFERENCIES_DIR = REPO_ROOT / "data" / "inferencies" / DEFAULT_VERSION
 # resta identifica la categoria (``traduccio``).
 _CODE_SUFFIX = re.compile(r"_\d+$")
 
+# Separa els trams numèrics d'un nom per poder ordenar-lo de manera natural.
+_DIGITS = re.compile(r"(\d+)")
+
+
+def _natural_key(path: Path) -> list[object]:
+    """Clau d'ordenació natural d'un camí.
+
+    Ordena els trams numèrics pel seu valor i no lexicogràficament, de manera que
+    ``traduccio_2`` va abans de ``traduccio_10``. Opera sobre el camí sencer, així
+    que manté l'agrupació per directori (p. ex. per model) i només canvia l'ordre
+    dels números dins de cada nom.
+
+    Args:
+        path: Camí del fitxer a ordenar.
+
+    Returns:
+        Llista alternada de text i enters, comparable amb la d'altres camins.
+    """
+    return [int(part) if part.isdigit() else part for part in _DIGITS.split(str(path))]
+
 
 class SchemaError(Exception):
     """Un fitxer YAML no compleix l'esquema esperat.
@@ -346,7 +366,7 @@ def load_prompts(
         category_ids: Mapa de codi de categoria a identificador.
         stats: Recompte que s'actualitza.
     """
-    for path in sorted(prompts_dir.glob("*.yaml")):
+    for path in sorted(prompts_dir.glob("*.yaml"), key=_natural_key):
         try:
             records = parse_prompt_file(path, version)
         except (SchemaError, yaml.YAMLError) as error:
@@ -366,7 +386,7 @@ def load_responses(session: Session, inferencies_dir: Path, version: str, stats:
         version: Versió del conjunt de dades.
         stats: Recompte que s'actualitza.
     """
-    for path in sorted(inferencies_dir.rglob("*.yaml")):
+    for path in sorted(inferencies_dir.rglob("*.yaml"), key=_natural_key):
         try:
             record = parse_inference_file(path, version)
         except (SchemaError, yaml.YAMLError) as error:

--- a/scripts/carrega_inferencies.py
+++ b/scripts/carrega_inferencies.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from prompts_yaml import normalize_prompts
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 # El model de dades i la configuració viuen al paquet backend/app.
@@ -76,10 +77,15 @@ class ResponseRecord:
 
 @dataclass
 class Stats:
-    """Recompte d'un tipus d'entitat carregada."""
+    """Recompte d'un tipus d'entitat carregada.
+
+    No hi ha categoria ``updated``: la càrrega és idempotent només si el contingut
+    és idèntic (``skipped``). Si una entitat ja existeix amb un contingut diferent,
+    es compta com a ``errors`` i s'exigeix una versió nova en comptes de modificar
+    la fila (vegeu :func:`upsert_response` i :func:`upsert_prompt`).
+    """
 
     inserted: int = 0
-    updated: int = 0
     skipped: int = 0
     errors: int = 0
 
@@ -145,43 +151,46 @@ def category_code_for(code: str) -> str:
     return _CODE_SUFFIX.sub("", code)
 
 
-def parse_prompt_file(path: Path, version: str) -> PromptRecord:
-    """Llegeix un fitxer de prompt i el normalitza.
+def parse_prompt_file(path: Path, version: str) -> list[PromptRecord]:
+    """Llegeix un fitxer de prompt i en normalitza les entrades.
 
-    Accepta tant un escalar de text (el cos del prompt) com un mapa amb els camps
-    ``code``/``id``, ``text`` i, opcionalment, ``category``.
+    Comparteix amb ``scripts/inferencia.py`` (via :func:`normalize_prompts`) el
+    reconeixement dels formats acceptats: un escalar de text (el cos del prompt),
+    un mapa amb els camps ``code``/``id``, ``text`` i, opcionalment, ``category``,
+    o una llista de mapes (diversos prompts en un sol fitxer).
 
     Args:
         path: Fitxer YAML del prompt.
         version: Versió del conjunt de dades.
 
     Returns:
-        Prompt normalitzat.
+        Prompts normalitzats (un per entrada del fitxer).
 
     Raises:
-        SchemaError: Si el contingut no és text ni mapa, o no té text.
+        SchemaError: Si el contingut no és cap dels formats acceptats, o alguna
+            entrada no té text.
     """
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
 
-    if isinstance(data, str):
-        code = path.stem
-        text = data
-        category_code = category_code_for(code)
-    elif isinstance(data, dict):
-        code = str(data.get("code") or data.get("id") or path.stem)
-        text = data.get("text")
-        category_code = str(data.get("category") or category_code_for(code))
-    else:
-        raise SchemaError(f"{path}: el prompt ha de ser un text o un mapa")
+    entries = normalize_prompts(data, path.stem)
+    if not entries:
+        raise SchemaError(f"{path}: el prompt ha de ser un text, un mapa o una llista de mapes")
 
-    text = _require(text, "el prompt no té text", path)
-    return PromptRecord(
-        version=version,
-        code=code,
-        category_code=category_code,
-        text=text.strip(),
-        source=path,
-    )
+    records = []
+    for entry in entries:
+        code = str(entry.get("code") or entry.get("id") or path.stem)
+        text = _require(entry.get("text"), "el prompt no té text", path)
+        category_code = str(entry.get("category") or category_code_for(code))
+        records.append(
+            PromptRecord(
+                version=version,
+                code=code,
+                category_code=category_code,
+                text=text.strip(),
+                source=path,
+            )
+        )
+    return records
 
 
 def parse_inference_file(path: Path, version: str) -> ResponseRecord:
@@ -236,6 +245,12 @@ def upsert_prompt(
 ) -> None:
     """Fa *upsert* d'un prompt per la clau ``(version, code)``.
 
+    Insereix si no existeix i omet si ja existeix amb el mateix contingut. Si
+    existeix amb un contingut diferent (text o categoria), ho compta com a error i
+    **no** modifica la fila: igual que les respostes, els prompts ja carregats
+    poden tenir vots associats, de manera que un canvi exigeix una versió nova en
+    comptes de mutar la fila existent.
+
     Args:
         session: Sessió de base de dades activa.
         record: Prompt normalitzat.
@@ -262,17 +277,27 @@ def upsert_prompt(
         )
         session.flush()
         stats.inserted += 1
-    elif existing.text != record.text or existing.category_id != category_id:
-        existing.text = record.text
-        existing.category_id = category_id
-        session.flush()
-        stats.updated += 1
-    else:
+    elif existing.text == record.text and existing.category_id == category_id:
         stats.skipped += 1
+    else:
+        LOGGER.error(
+            "%s: el prompt (%s/%s) ja existeix amb un contingut diferent; "
+            "publica'l amb una versió nova en comptes de modificar-lo",
+            record.source,
+            record.version,
+            record.code,
+        )
+        stats.errors += 1
 
 
 def upsert_response(session: Session, record: ResponseRecord, stats: Stats) -> None:
     """Fa *upsert* d'una resposta per la clau ``(prompt_id, model)``.
+
+    Insereix si no existeix i omet si ja existeix amb el mateix contingut. Si
+    existeix amb un contingut diferent (text o metadades), ho compta com a error i
+    **no** modifica la fila: els vots existents apunten a aquest ``response_id`` i
+    sobreescriure'n el text els invalidaria semànticament. Un canvi de contingut
+    exigeix, doncs, una versió nova en comptes de mutar la resposta.
 
     Args:
         session: Sessió de base de dades activa.
@@ -303,13 +328,18 @@ def upsert_response(session: Session, record: ResponseRecord, stats: Stats) -> N
         )
         session.flush()
         stats.inserted += 1
-    elif existing.text != record.text or existing.inference_metadata != record.metadata:
-        existing.text = record.text
-        existing.inference_metadata = record.metadata
-        session.flush()
-        stats.updated += 1
-    else:
+    elif existing.text == record.text and existing.inference_metadata == record.metadata:
         stats.skipped += 1
+    else:
+        LOGGER.error(
+            "%s: la resposta (%s/%s) ja existeix amb un contingut diferent; "
+            "publica-la amb una versió nova en comptes de modificar-la, perquè els "
+            "vots existents apunten al text actual",
+            record.source,
+            record.prompt_code,
+            record.model,
+        )
+        stats.errors += 1
 
 
 def load_prompts(
@@ -330,12 +360,13 @@ def load_prompts(
     """
     for path in sorted(prompts_dir.glob("*.yaml")):
         try:
-            record = parse_prompt_file(path, version)
+            records = parse_prompt_file(path, version)
         except (SchemaError, yaml.YAMLError) as error:
             LOGGER.error("prompt no vàlid: %s", error)
             stats.errors += 1
             continue
-        upsert_prompt(session, record, category_ids, stats)
+        for record in records:
+            upsert_prompt(session, record, category_ids, stats)
 
 
 def load_responses(session: Session, inferencies_dir: Path, version: str, stats: Stats) -> None:
@@ -391,10 +422,7 @@ def run_load(
 
 
 def _format_stats(stats: Stats) -> str:
-    return (
-        f"inserits={stats.inserted} actualitzats={stats.updated} "
-        f"omesos={stats.skipped} errors={stats.errors}"
-    )
+    return f"inserits={stats.inserted} omesos={stats.skipped} errors={stats.errors}"
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/inferencia.py
+++ b/scripts/inferencia.py
@@ -20,6 +20,14 @@ from transformers import (
     BitsAndBytesConfig,
 )
 
+# Helper compartit amb scripts/carrega_inferencies.py. S'importa tant si el mòdul
+# s'executa com a script (scripts/ al sys.path) com si es carrega com a paquet
+# (scripts.inferencia, amb l'arrel del repositori al sys.path, com fan els tests).
+try:
+    from prompts_yaml import normalize_prompts
+except ModuleNotFoundError:  # pragma: no cover
+    from scripts.prompts_yaml import normalize_prompts
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ConfigDict = dict[str, Any]
 Prompt = dict[str, Any]
@@ -170,16 +178,7 @@ def load_prompts(
         with prompt_file.open("r", encoding="utf-8") as file:
             data = yaml.safe_load(file)
 
-        if isinstance(data, list):
-            prompts = data
-        elif isinstance(data, dict):
-            prompts = [data]
-        elif isinstance(data, str):
-            prompts = [{"id": prompt_file.stem, "text": data}]
-        else:
-            continue
-
-        for prompt in prompts:
+        for prompt in normalize_prompts(data, prompt_file.stem):
             prompt["_path_origen"] = str(prompt_file.relative_to(root))
             prompt_list.append(prompt)
 

--- a/scripts/prompts_yaml.py
+++ b/scripts/prompts_yaml.py
@@ -1,0 +1,39 @@
+"""Lectura compartida dels fitxers de prompt en YAML.
+
+Tant la canonada d'inferència (``scripts/inferencia.py``) com la càrrega a la
+base de dades (``scripts/carrega_inferencies.py``) parteixen dels mateixos
+fitxers de prompt. Un fitxer pot ser un escalar de text, un mapa o una llista de
+mapes. Centralitzem aquí la normalització perquè les dues vies no divergeixin
+(per exemple, que una accepti llistes i l'altra no).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_prompts(data: Any, default_code: str) -> list[dict[str, Any]]:
+    """Converteix el contingut d'un fitxer de prompt en una llista d'entrades.
+
+    Accepta els tres formats presents al repositori:
+
+    - un escalar de text: el cos del prompt (el codi és ``default_code``);
+    - un mapa amb els camps del prompt (``text`` i, opcionalment, ``code``/``id``);
+    - una llista de mapes (diversos prompts en un sol fitxer).
+
+    Args:
+        data: Valor ja carregat del YAML.
+        default_code: Codi o identificador a assignar quan el prompt no en porta
+            (típicament el nom del fitxer sense extensió).
+
+    Returns:
+        Llista d'entrades de prompt, cada una un mapa. És buida si ``data`` no és
+        cap dels formats reconeguts.
+    """
+    if isinstance(data, str):
+        return [{"id": default_code, "text": data}]
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        return [entry for entry in data if isinstance(entry, dict)]
+    return []


### PR DESCRIPTION
Tanca #14.

Converteix `scripts/carrega_inferencies.py` (fins ara un esbós comentat) en un carregador funcional i idempotent que publica els fitxers YAML versionats a les taules `prompts` i `responses`.

## Abast (v1)

- **Prompts** (`data/prompts/v1/*.yaml`): *upsert* per la clau natural `(version, code)`. El `code` és el nom del fitxer i la categoria es dedueix del prefix (`traduccio_1` -> `traduccio`); la versió, del nom del directori.
- **Respostes** (`data/inferencies/v1/<model_id>/*.yaml`): *upsert* per `(prompt_id, model)`. El text visible (`output.answer`) va a `text`; el raonament intern i les metadades de generació/execució van a `inference_metadata` (JSONB), de manera que la resposta es manté a cegues per a l'avaluació.
- **Idempotent, sense sobreescriure**: torna a executar-lo classifica cada fila com a inserida o omesa (ja existeix amb el mateix contingut) i no duplica files. Si una entitat ja existeix amb la mateixa clau però amb un contingut diferent, ho compta com a error i exigeix una versió nova en comptes de mutar la fila (els vots existents apunten al mateix `response_id`). Això s'aplica tant a respostes com a prompts.
- **Connexió** a través d'`app.config` (el mateix rol d'aplicació amb permisos limitats que fa servir el servei).
- **Resum a stdout** amb els recomptes de prompts i respostes.
- **Errors clars**: registra un error quan un YAML no compleix l'esquema (categoria o prompt desconegut, camps obligatoris absents, YAML mal format) i acaba amb codi de sortida 1, sense aturar la resta de la càrrega.

## Ús

```bash
uv --project backend run python scripts/carrega_inferencies.py
```

S'hi pot passar `--prompts-dir`, `--inferencies-dir` i `--version`. Documentat a `scripts/README.md`.

## Tests

S'afegeix `backend/tests/test_carrega_inferencies.py` (10 tests contra PostgreSQL real): inserció, idempotència, enllaç prompt-resposta, raonament fora del text visible, actualització en canvi, i les rutes d'error (prompt desconegut, categoria desconeguda, camp obligatori absent, YAML mal format). S'afegeix `pyyaml` a les dependències del backend perquè el carregador es pugui importar i provar des de l'entorn del backend.

Verificat localment: 26/26 tests passen, `ruff check`/`ruff format --check`/`alembic check` net, i una execució extrem a extrem confirma inserció, idempotència (segona passada tot *omès*), detecció de canvis i codi de sortida 1 en error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

