### PR TITLE
Feature/api ranking

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -19,13 +19,17 @@ Optionally run `cd backend && uv run pre-commit install` to install the lint/for
 
 ## Structure
 
-```
+```text
 app/
   config.py     # connection settings (.env)
   db.py         # SQLAlchemy engine and base class
   models.py     # data models
+  schemas.py    # Pydantic models for API validation
+  routes/       # FastAPI endpoints (task, vote, ranking)
+  services/     # logic and database operations
+  ranking/      # ranking module
 migrations/     # Alembic migrations
-tests/          # model tests
+tests/          # tests
 ```
 
 ## Data model
@@ -45,6 +49,83 @@ On first startup, `docker compose` provisions:
 - **arena_cat_test** — test database, derived from `POSTGRES_DB` (`${POSTGRES_DB}_test`).
 - **arena_app** — application role with limited permissions (DML only). Migrations run
   with the superuser.
+
+## API
+
+El backend de FastAPI exposa els següents endpoints:
+
+### `GET /api/task`
+
+Obté una nova tasca (un prompt amb dues respostes de models diferents) per a que un usuari l'avaluï.
+
+**Paràmetres de la URL:**
+- `category_code` (string, obligatori): La categoria de la tasca sol·licitada (p. ex., `correccio`).
+- `session_id` (string, obligatori): L'identificador de sessió de l'usuari per evitar repetir tasques.
+
+**Resposta (200 OK):**
+```json
+{
+  "prompt": "El gat es blau",
+  "response_a": "El gat és blau.",
+  "response_b": "El gat es color blau.",
+  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+
+### `POST /api/vote`
+
+Registra el vot d'un usuari sobre una tasca prèviament demanada.
+
+**Body (JSON):**
+- `winner` (string): Quin model ha guanyat. Valors possibles: `"a"`, `"b"`, `"tie"` o `"neither"`.
+- `token` (string): El JWT generat per l'endpoint `/api/task` (conté els IDs del prompt i les respostes).
+ 
+**Resposta (200 OK):**
+```json
+{
+  "status": "ok"
+}
+```
+
+
+### `GET /api/ranking`
+
+Retorna el rànquing actual de models per a una categoria específica.
+
+**Paràmetres de la URL:**
+- `category_code` (string, obligatori): El codi de la categoria a consultar.
+
+**Resposta (200 OK):**
+```json
+{
+  "category_code": "correccio",
+  "n_votes_total": 390,
+  "n_votes_decisive": 358,
+  "n_ties": 23,
+  "n_neither": 9,
+  "models": ["gemma-3-4b-it", "qwen-3.5-9b", "salamandra-7b-instruct"],
+  "best_model": "gemma-3-4b-it",
+  "bt_skills": {
+    "gemma-3-4b-it": 0.27,
+    "qwen-3.5-9b": -0.04,
+    "salamandra-7b-instruct": -0.23
+  },
+  "raw_pairwise": [
+    {
+      "model_a": "gemma-3-4b-it",
+      "model_b": "qwen-3.5-9b",
+      "wins_a": 40,
+      "wins_b": 25,
+      "ties": 5,
+      "neither": 2,
+      "win_rate_a": 0.615
+    }
+  ],
+  "cycle_detected": false,
+  "cycle_path": []
+}
+```
 
 ## Tests
 

--- a/backend/app/routes/ranking.py
+++ b/backend/app/routes/ranking.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.db import get_db
-from app.services import ranking_service
 from app.schemas import RankingResponse
+from app.services import ranking_service
 
 router = APIRouter()
 

--- a/backend/app/routes/ranking.py
+++ b/backend/app/routes/ranking.py
@@ -1,8 +1,21 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.orm import Session
+
+from app.db import get_db
+from app.services import ranking_service
+from app.schemas import RankingResponse
 
 router = APIRouter()
 
 
 @router.get("/ranking")
-def get_ranking() -> list[dict]:
-    raise HTTPException(status_code=501, detail="No implementat")
+def get_ranking(category_code: str, db: Session = Depends(get_db)) -> RankingResponse:
+    """
+    Retorna el rànquing per a una categoria.
+    Args:
+        db: Sessió de base de dades.
+        category_code: Codi de la categoria.
+    Returns:
+        RankingResponse: objecte amb el rànquing per a la categoria.
+    """
+    return RankingResponse(**ranking_service.get_ranking_per_category(db, category_code))

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -21,6 +21,7 @@ class VoteResponse(BaseModel):
     status: str = "ok"
 
 
+<<<<<<< HEAD
 
 class RegisterRequest(BaseModel):
     email: EmailStr
@@ -94,6 +95,8 @@ class ExportDataResponse(BaseModel):
     user: ExportUserResponse
     votes: list[ExportVoteResponse]
 
+=======
+>>>>>>> a73e100 (test: afegir tests api ranking)
 class PairwiseStat(BaseModel):
     model_a: str
     model_b: str
@@ -102,6 +105,7 @@ class PairwiseStat(BaseModel):
     ties: int
     neither: int
     win_rate_a: float | None
+
 
 class RankingResponse(BaseModel):
     category_code: str

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -21,8 +21,6 @@ class VoteResponse(BaseModel):
     status: str = "ok"
 
 
-
-
 class RegisterRequest(BaseModel):
     email: EmailStr
     password: str = Field(min_length=8, max_length=128)
@@ -96,7 +94,6 @@ class ExportDataResponse(BaseModel):
     votes: list[ExportVoteResponse]
 
 
-
 class PairwiseStat(BaseModel):
     model_a: str
     model_b: str
@@ -119,4 +116,3 @@ class RankingResponse(BaseModel):
     raw_pairwise: list[PairwiseStat]
     cycle_detected: bool
     cycle_path: list[str]
-

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -21,7 +21,7 @@ class VoteResponse(BaseModel):
     status: str = "ok"
 
 
-<<<<<<< HEAD
+
 
 class RegisterRequest(BaseModel):
     email: EmailStr
@@ -95,8 +95,8 @@ class ExportDataResponse(BaseModel):
     user: ExportUserResponse
     votes: list[ExportVoteResponse]
 
-=======
->>>>>>> a73e100 (test: afegir tests api ranking)
+
+
 class PairwiseStat(BaseModel):
     model_a: str
     model_b: str

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -21,6 +21,7 @@ class VoteResponse(BaseModel):
     status: str = "ok"
 
 
+
 class RegisterRequest(BaseModel):
     email: EmailStr
     password: str = Field(min_length=8, max_length=128)
@@ -92,3 +93,26 @@ class ExportUserResponse(BaseModel):
 class ExportDataResponse(BaseModel):
     user: ExportUserResponse
     votes: list[ExportVoteResponse]
+
+class PairwiseStat(BaseModel):
+    model_a: str
+    model_b: str
+    wins_a: int
+    wins_b: int
+    ties: int
+    neither: int
+    win_rate_a: float | None
+
+class RankingResponse(BaseModel):
+    category_code: str
+    n_votes_total: int
+    n_votes_decisive: int
+    n_ties: int
+    n_neither: int
+    models: list[str]
+    best_model: str | None
+    bt_skills: dict[str, float]
+    raw_pairwise: list[PairwiseStat]
+    cycle_detected: bool
+    cycle_path: list[str]
+

--- a/backend/app/services/ranking_service.py
+++ b/backend/app/services/ranking_service.py
@@ -1,0 +1,20 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+
+from app.ranking.ranking import compute_ranking
+from app.models import Category
+
+def get_ranking_per_category(db: Session, category_code: str) -> dict:
+    """
+    Obté el ranking per a una categoria.
+    Args:
+        db: Sessió de base de dades.
+        category_code: Codi de la categoria.
+    Returns:
+        Diccionari amb el ranking per a la categoria.
+    """
+    category = db.scalar(select(Category).where(Category.code == category_code))
+    if category is None:
+        raise HTTPException(status_code=404, detail=f"No existeix la categoria: {category_code}.")
+    return compute_ranking(db, category_code)

--- a/backend/app/services/ranking_service.py
+++ b/backend/app/services/ranking_service.py
@@ -1,9 +1,10 @@
+from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from fastapi import HTTPException
 
-from app.ranking.ranking import compute_ranking
 from app.models import Category
+from app.ranking.ranking import compute_ranking
+
 
 def get_ranking_per_category(db: Session, category_code: str) -> dict:
     """

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -306,3 +306,49 @@ def test_export_data_requires_session(client):
     response = client.get("/api/auth/export")
 
     assert response.status_code == 401
+
+
+def test_get_ranking_unkwnown_category(client):
+    """Prova què passa quan intentem obtenir el rànquing d'una categoria no existent."""
+    category_code = "cat_inexistent"
+    response = client.get(f"/api/ranking?category_code={category_code}")
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"No existeix la categoria: {category_code}."
+
+
+def test_get_ranking_empty_category(client, session):
+    """Prova què passa quan intentem obtenir el rànquing d'una categoria buida."""
+    # Creem una categoria sense vots
+    c = Category(code="test_cat", name="Categoria de prova")
+    session.add(c)
+    session.commit()
+
+    response = client.get(f"/api/ranking?category_code={c.code}")
+    assert response.json()["best_model"] is None
+    assert response.json()["bt_skills"] == {}
+
+
+def test_get_ranking_full_category(client, session):
+    """Prova què passa quan intentem obtenir el rànquing d'una categoria amb vots."""
+    # Recuperem la categoria 'correccio'
+    c = session.scalar(select(Category).where(Category.code == "correccio"))
+
+    # Inserim dades falses
+    p = Prompt(version="v1", code="correccio", category_id=c.id, text="El gat es blau")
+    session.add(p)
+    session.commit()
+
+    r1 = Response(prompt_id=p.id, model="model_1", text="El gat és blau")
+    r2 = Response(prompt_id=p.id, model="model_2", text="El gat es color blau")
+    session.add_all([r1, r2])
+    session.commit()
+
+    v1 = Vote(prompt_id=p.id, response_a_id=r1.id, response_b_id=r2.id, winner="a")
+    session.add(v1)
+    session.commit()
+
+    # Obtenim resposta
+    response = client.get(f"/api/ranking?category_code={c.code}")
+    assert response.status_code == 200
+    assert response.json()["best_model"] == "model_1"
+    assert response.json()["bt_skills"] != {}


### PR DESCRIPTION
## Descripció

Implementa la funcionalitat per exposar el rànquing de models per categoria.

### Canvis principals
- **Nou Endpoint**: S'ha substituït el `501 Not Implemented` per l'endpoint `GET /api/ranking?category_code=...`.
- **Nou Servei**: S'ha creat `app/services/ranking_service.py` per abstraure l'accés a dades i orquestrar el càlcul del rànquing.
- **Schemas**: S'han afegit els models Pydantic `RankingResponse` i `PairwiseStat` a `app/schemas.py` per validar la resposta de l'API.
- **Gestió d'Errors**: 
  - Si una categoria és inexistent a la BD, es retorna un error explícit `404 Not Found`.
  - Si una categoria existeix però no té vots, es retorna un `200 OK` (amb llistes buides i recomptes a zero).
- **Documentació**: S'ha actualitzat l'estructura de fitxers al `README.md` i s'hi ha afegit una referència completa dels endpoints de l'API.

### Tests afegits
S'ha afegit tests al fitxer `test_api.py`:
- `[x]` Categoria desconeguda -> retorna `404`.
- `[x]` Categoria sense vots -> retorna `200` amb resposta buida coherent.
- `[x]` Categoria amb vots -> retorna dades correctes.