### PR TITLE
feat: afegir endpoint GET /api/auth/session

### DIFF
--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -6,7 +6,7 @@ autenticat (verificat o no) directament a la signatura dels handlers.
 
 from typing import Annotated
 
-from fastapi import Cookie, Depends
+from fastapi import Cookie, Depends, HTTPException
 from sqlalchemy.orm import Session as OrmSession
 
 from app.config import get_settings
@@ -28,5 +28,19 @@ def get_current_verified_user(db: DbSession, session_token: SessionCookie = None
     return auth_service.resolve_session_user(db, session_token, require_verified=True)
 
 
+def get_optional_user(db: DbSession, session_token: SessionCookie = None) -> User | None:
+    """Retorna l'usuari autenticat, o `None` si no hi ha cap sessió vàlida.
+
+    A diferència de `get_current_user`, que llança 401, aquí la manca de sessió és
+    un resultat vàlid. Ho fan servir els endpoints que consulten l'autenticació en
+    comptes d'exigir-la.
+    """
+    try:
+        return auth_service.resolve_session_user(db, session_token)
+    except HTTPException:
+        return None
+
+
 CurrentUser = Annotated[User, Depends(get_current_user)]
 CurrentVerifiedUser = Annotated[User, Depends(get_current_verified_user)]
+OptionalUser = Annotated[User | None, Depends(get_optional_user)]

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Cookie, Response
 
 from app.config import get_settings
-from app.deps import CurrentUser, DbSession
+from app.deps import CurrentUser, DbSession, OptionalUser
 from app.schemas import (
     DeleteAccountRequest,
     DeleteAccountResponse,
@@ -12,6 +12,7 @@ from app.schemas import (
     LogoutResponse,
     RegisterRequest,
     RegisterResponse,
+    SessionResponse,
     VerifyEmailRequest,
     VerifyEmailResponse,
 )
@@ -48,6 +49,24 @@ def login(payload: LoginRequest, response: Response, db: DbSession) -> LoginResp
     )
 
     return LoginResponse(status="logged_in")
+
+
+@router.get("/auth/session")
+def get_session(current_user: OptionalUser) -> SessionResponse:
+    """Indica si la cookie rebuda correspon a una sessió activa.
+
+    El client ho consulta en carregar la pàgina per saber si ha de demanar les
+    credencials. Respon 200 encara que no hi hagi sessió, de manera que un 401
+    sempre vol dir que la sessió s'ha perdut i no que mai n'hi hagi hagut cap.
+    """
+    if current_user is None:
+        return SessionResponse(authenticated=False)
+
+    return SessionResponse(
+        authenticated=True,
+        email=current_user.email,
+        email_verified=current_user.email_verified_at is not None,
+    )
 
 
 @router.post("/auth/logout")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -64,6 +64,14 @@ class LoginResponse(BaseModel):
     status: str = "logged_in"
 
 
+class SessionResponse(BaseModel):
+    """Estat de la sessió. `authenticated` fals no és cap error: vol dir que no n'hi ha."""
+
+    authenticated: bool
+    email: str | None = None
+    email_verified: bool = False
+
+
 class LogoutRequest(BaseModel):
     token: str
 

--- a/backend/tests/test_auth_api.py
+++ b/backend/tests/test_auth_api.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select
@@ -306,6 +306,74 @@ def test_export_data_requires_session(client):
     response = client.get("/api/auth/export")
 
     assert response.status_code == 401
+
+
+def test_session_returns_authenticated_user(client, logged_in_user):
+    logged_in_user("session_ok@example.com")
+
+    response = client.get("/api/auth/session")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "authenticated": True,
+        "email": "session_ok@example.com",
+        "email_verified": True,
+    }
+
+
+def test_session_without_cookie_returns_unauthenticated(client):
+    response = client.get("/api/auth/session")
+
+    assert response.status_code == 200
+    assert response.json() == {"authenticated": False, "email": None, "email_verified": False}
+
+
+def test_session_with_invalid_cookie_returns_unauthenticated(client):
+    client.cookies.set(get_settings().cookie_name, "token_inventat")
+
+    response = client.get("/api/auth/session")
+
+    assert response.status_code == 200
+    assert response.json()["authenticated"] is False
+
+
+def test_session_after_logout_returns_unauthenticated(client, logged_in_user):
+    logged_in_user("session_logout@example.com")
+
+    assert client.post("/api/auth/logout").status_code == 200
+
+    response = client.get("/api/auth/session")
+    assert response.status_code == 200
+    assert response.json()["authenticated"] is False
+
+
+def test_session_with_expired_session_returns_unauthenticated(client, session, logged_in_user):
+    user = logged_in_user("session_expired@example.com")
+
+    stored_session = session.scalar(select(Session).where(Session.user_id == user.id))
+    stored_session.expires_at = datetime.now(UTC) - timedelta(hours=1)
+    session.commit()
+
+    response = client.get("/api/auth/session")
+
+    assert response.status_code == 200
+    assert response.json()["authenticated"] is False
+
+
+def test_session_reports_unverified_email(client, create_user, login):
+    # Amb REQUIRE_EMAIL_VERIFICATION desactivat l'usuari sense verificar pot iniciar
+    # sessió, però el client ha de poder distingir-lo d'un de verificat.
+    create_user("session_unverified@example.com", verified=False)
+    login("session_unverified@example.com")
+
+    response = client.get("/api/auth/session")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "authenticated": True,
+        "email": "session_unverified@example.com",
+        "email_verified": False,
+    }
 
 
 def test_get_ranking_unkwnown_category(client):

--- a/docs/auth_flow_manual.md
+++ b/docs/auth_flow_manual.md
@@ -96,7 +96,31 @@ La cookie `session_token` queda desada a `cookies.txt`.
 
 ---
 
-## 6. Obtenir una tasca
+## 6. Consultar l'estat de la sessió
+
+```bash
+curl -s -b "$COOKIES" "$BASE_URL/api/auth/session"
+```
+
+Resposta esperada (`200`):
+
+```json
+{"authenticated": true, "email": "prova@example.com", "email_verified": true}
+```
+
+Sense cookie, o amb una de caducada o revocada, respon igualment `200`:
+
+```json
+{"authenticated": false, "email": null, "email_verified": false}
+```
+
+> No tenir sessió és un estat normal, no un error: per això aquest endpoint no
+> retorna mai `401`. Serveix perquè el client sàpiga si ha de demanar les
+> credencials abans de fer cap altra crida.
+
+---
+
+## 7. Obtenir una tasca
 
 ```bash
 curl -s -b "$COOKIES" "$BASE_URL/api/task?category_code=correccio"
@@ -123,7 +147,7 @@ TASK_TOKEN='<enganxa-aquí-el-token-de-la-tasca>'
 
 ---
 
-## 7. Consultar el progrés
+## 8. Consultar el progrés
 
 ```bash
 curl -s -b "$COOKIES" "$BASE_URL/api/task/progress"
@@ -137,7 +161,7 @@ Resposta esperada (`200`):
 
 ---
 
-## 8. Emetre un vot
+## 9. Emetre un vot
 
 ```bash
 curl -s -b "$COOKIES" -X POST "$BASE_URL/api/vote" \
@@ -153,7 +177,7 @@ Resposta esperada (`200`):
 
 ---
 
-## 9. Ometre una tasca
+## 10. Ometre una tasca
 
 Si no vols votar la tasca carregada:
 
@@ -173,7 +197,7 @@ La mateixa parella de respostes no es tornarà a oferir al mateix usuari.
 
 ---
 
-## 10. Exportar les dades (RGPD)
+## 11. Exportar les dades (RGPD)
 
 ```bash
 curl -s -b "$COOKIES" "$BASE_URL/api/auth/export"
@@ -183,7 +207,7 @@ Resposta esperada (`200`): objecte amb `user` i la llista de `votes`.
 
 ---
 
-## 11a. Logout (deixa el compte viu)
+## 12a. Logout (deixa el compte viu)
 
 ```bash
 curl -s -b "$COOKIES" -X POST "$BASE_URL/api/auth/logout"
@@ -195,7 +219,7 @@ Resposta esperada (`200`):
 {"status": "logged_out"}
 ```
 
-## 11b. Baixa del compte (anonimització RGPD)
+## 12b. Baixa del compte (anonimització RGPD)
 
 Alternativa al logout: dona de baixa el compte reautenticant amb la contrasenya.
 
@@ -213,7 +237,7 @@ Resposta esperada (`200`):
 
 ---
 
-## 12. (Control) La sessió ja no és vàlida → 401
+## 13. (Control) La sessió ja no és vàlida → 401
 
 Després del logout o la baixa, qualsevol crida autenticada ha de fallar:
 


### PR DESCRIPTION
Permet al client saber si la cookie de sessió encara és vàlida abans de fer cap altra crida. Respon sempre 200, de manera que un 401 vol dir sempre que la sessió s'ha perdut i no que mai n'hi hagi hagut cap.

Afegeix get_optional_user, que reaprofita resolve_session_user però retorna None en comptes de llançar excepció quan no hi ha sessió vàlida.