### PR TITLE
docs: neteja «Què falta» del README del frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -119,15 +119,7 @@ s'hagi decidit.
 
 ## Què falta
 
-- **i18n** (`i18next` + `react-i18next`): Garbellaveus serveix català i anglès.
-- **Encaminament** (`react-router-dom`): aquí tot passa en una sola pantalla.
 - Pantalles de rànquing i estadístiques, i gestió del compte (exportació i baixa
   RGPD, que el backend ja implementa però no són accessibles des de la interfície).
-
-### Endpoints que ajudarien
-
-| Endpoint | Per a què |
-|---|---|
-| `GET /api/categories` | Ara les categories són a `src/types.ts`, escrites a mà. |
-| Progrés per categoria | `GET /api/task/progress` només dona el total global. |
-| `assess_confidence` al rànquing | Ja està implementat i provat al backend, però cap ruta el crida. |
+  Si acaben necessitant URL pròpia (compartir enllaç, botó «enrere»), caldrà
+  `react-router-dom`; si no, es poden fer igual que ara, amb estat de React.


### PR DESCRIPTION
## Resum
- Treu i18n de «Què falta»: Arena Cat només serà en català, a diferència de Garbellaveus (ca+en).
- Treu «Encaminament» com a cosa pendent: només farà falta `react-router-dom` si les pantalles futures (rànquing, compte) necessiten URL pròpia; si no, es poden fer amb estat de React com ara.
- Treu la taula «Endpoints que ajudarien»: el que tenim ara ja funciona correctament.