### PR TITLE
feat: afegeix una imatge per carregar inferències en producció

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ build:
   services:
     - docker:dind
   before_script:
+    - apk add --no-cache git
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
     - docker info
   stage: build
@@ -32,6 +33,13 @@ build:
     - export DOCKER_PATH=frontend/Dockerfile
     - export DOCKER_CONTEXT=./frontend
     - docker build --build-arg VITE_API_BASE_URL=https://api.softcatala.org/arena_cat/v1/api -f $DOCKER_PATH --tag $IMAGE_NAME $DOCKER_CONTEXT
+    - docker push $IMAGE_NAME
+    # Inference loader
+    - git fetch origin dades_inferencia:refs/remotes/origin/dades_inferencia
+    - git checkout origin/dades_inferencia -- data/inferencies
+    - export REPO_NAME=$CI_REGISTRY_IMAGE/arena-cat-load-inferences
+    - export IMAGE_NAME=$REPO_NAME:$CI_COMMIT_REF_SLUG
+    - docker build -f Dockerfile.load-inferences --tag $IMAGE_NAME .
     - docker push $IMAGE_NAME
 
 deploy:

--- a/Dockerfile.load-inferences
+++ b/Dockerfile.load-inferences
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+# Instal·lem `uv` copiant-lo directament de la seva imatge oficial.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+WORKDIR /app/backend
+
+COPY backend/pyproject.toml backend/uv.lock ./
+RUN uv sync --frozen --no-install-project
+
+WORKDIR /app
+
+COPY backend/app /app/backend/app
+COPY scripts/carrega_inferencies.py /app/scripts/carrega_inferencies.py
+COPY data/prompts/v1 /app/data/prompts/v1
+COPY data/inferencies/v1 /app/data/inferencies/v1
+
+CMD ["uv", "--project", "backend", "run", "python", "scripts/carrega_inferencies.py", "--prompts-dir", "data/prompts/v1", "--inferencies-dir", "data/inferencies/v1", "--version", "v1"]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ La inferència pot requerir `HF_TOKEN` i prou memòria per als models configurat
 fes servir `CONFIG=config/inferencia/inferencia_local_config.yaml make inferences`.
 Per al detall de la canonada, consulta [scripts/README.md](scripts/README.md).
 
+En producció, per carregar les inferències precomputades, executa una vegada la
+imatge `arena-cat-load-inferences` dins la xarxa on hi ha PostgreSQL:
+
+```bash
+docker run --rm --network arena-cat_arena_cat --env-file .env_loader \
+  registry.softcatala.org/github/arena-cat/arena-cat-load-inferences:main
+```
+
 També hi ha objectius per a tasques habituals:
 
 ```bash


### PR DESCRIPTION
Afegeix una imatge Docker d’un sol ús, construïda per GitLab, que empaqueta les inferències precomputades de la branca de dades i les carrega a PostgreSQL de producció executant-la manualment amb .env_loader.