### PR TITLE
fix: millora la claredat de la pantalla d'avaluació

### DIFF
--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -121,7 +121,7 @@ export default function Login({ onLoggedIn }: { onLoggedIn: () => void }) {
                 <a
                   href="https://www.softcatala.org/avis-legal/"
                   target="_blank"
-                  rel="noreferrer"
+                  rel="noopener noreferrer"
                   className="underline hover:text-brand-700"
                 >
                   avís legal

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -115,7 +115,19 @@ export default function Login({ onLoggedIn }: { onLoggedIn: () => void }) {
                 onChange={(event) => setConsent(event.target.checked)}
                 className="mt-0.5 h-4 w-4 shrink-0 accent-brand-500"
               />
-              <span>Accepto el tractament de les meves dades per participar en l'avaluació.</span>
+              <span>
+                Accepto el tractament de les meves dades per participar en l'avaluació, d'acord amb
+                l'{" "}
+                <a
+                  href="https://www.softcatala.org/avis-legal/"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline hover:text-brand-700"
+                >
+                  avís legal
+                </a>
+                .
+              </span>
             </label>
           </>
         )}

--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,0 +1,97 @@
+import { useLayoutEffect, useState, type RefObject } from "react";
+
+export interface OnboardingStep {
+  ref: RefObject<HTMLElement | null>;
+  title: string;
+  text: string;
+}
+
+const TOOLTIP_WIDTH = 288;
+const GAP = 12;
+
+/** Tutorial de primer ús: assenyala, un per un, els blocs clau de la pantalla d'avaluació. */
+export default function Onboarding({
+  steps,
+  onDone,
+}: {
+  steps: OnboardingStep[];
+  onDone: () => void;
+}) {
+  const [index, setIndex] = useState(0);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const step = steps[index];
+
+  useLayoutEffect(() => {
+    const target = step.ref.current;
+    if (!target) return;
+
+    target.scrollIntoView({ block: "center", behavior: "smooth" });
+
+    const update = () => setRect(target.getBoundingClientRect());
+    update();
+    // El `scrollIntoView` és animat: recalculem un cop acabat perquè el
+    // requadre no quedi assenyalant la posició d'abans de l'scroll.
+    const afterScroll = setTimeout(update, 350);
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      clearTimeout(afterScroll);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [step]);
+
+  function next() {
+    if (index === steps.length - 1) onDone();
+    else setIndex(index + 1);
+  }
+
+  if (!rect) return null;
+
+  const pad = 8;
+  const spaceBelow = window.innerHeight - rect.bottom;
+  const tooltipTop =
+    spaceBelow > 200 ? rect.bottom + pad + GAP : Math.max(GAP, rect.top - pad - GAP - 180);
+  const tooltipLeft = Math.min(Math.max(GAP, rect.left), window.innerWidth - TOOLTIP_WIDTH - GAP);
+
+  return (
+    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label="Tutorial">
+      <div
+        className="pointer-events-none absolute rounded-lg transition-all duration-300"
+        style={{
+          top: rect.top - pad,
+          left: rect.left - pad,
+          width: rect.width + pad * 2,
+          height: rect.height + pad * 2,
+          boxShadow: "0 0 0 9999px rgba(15, 23, 42, 0.65)",
+        }}
+      />
+      <div
+        className="absolute rounded-lg bg-white p-4 shadow-xl transition-all duration-300"
+        style={{ top: tooltipTop, left: tooltipLeft, width: TOOLTIP_WIDTH }}
+      >
+        <p className="mb-1 text-xs font-semibold tracking-wide text-brand-600 uppercase">
+          Pas {index + 1} de {steps.length}
+        </p>
+        <h3 className="mb-1 font-semibold text-slate-900">{step.title}</h3>
+        <p className="mb-3 text-sm text-slate-600">{step.text}</p>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onDone}
+            className="text-sm text-slate-500 underline hover:text-slate-700"
+          >
+            Omet el tutorial
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            className="rounded-md bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-600"
+          >
+            {index === steps.length - 1 ? "Entesos" : "Següent"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
 
 export interface OnboardingStep {
   ref: RefObject<HTMLElement | null>;
@@ -39,7 +39,19 @@ export default function Onboarding({
       window.removeEventListener("resize", update);
       window.removeEventListener("scroll", update, true);
     };
-  }, [step]);
+    // `step` és un objecte nou a cada render del pare (p. ex. pel compte
+    // enrere de la tasca): dependre'n reexecutaria l'scroll cada segon.
+    // `index` és l'únic canvi real que ens interessa.
+  }, [index]);
+
+  // Tanca amb Esc, com qualsevol diàleg modal.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") onDone();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onDone]);
 
   function next() {
     if (index === steps.length - 1) onDone();

--- a/frontend/src/components/TaskView.tsx
+++ b/frontend/src/components/TaskView.tsx
@@ -4,6 +4,7 @@ import { api, ApiError } from "../api";
 import { splitPrompt } from "../diff";
 import { clearTask, loadSavedTask, saveTask, secondsUntilVote } from "../taskStore";
 import { CATEGORIES, type CategoryFilter, type Progress, type Task, type Winner } from "../types";
+import Onboarding, { type OnboardingStep } from "./Onboarding";
 import ProgressBar from "./ProgressBar";
 import ResponseCard from "./ResponseCard";
 
@@ -27,6 +28,11 @@ export default function TaskView() {
   const [remaining, setRemaining] = useState(0);
   /** No queden tasques per al filtre actual (el backend ha respost 404). */
   const [exhausted, setExhausted] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const headerRef = useRef<HTMLElement>(null);
+  const originalTextRef = useRef<HTMLElement>(null);
+  const responsesRef = useRef<HTMLDivElement>(null);
+  const voteRef = useRef<HTMLDivElement>(null);
 
   const loadProgress = useCallback(async () => {
     // El progrés és informatiu: si falla, no bloquegem l'avaluació.
@@ -171,6 +177,33 @@ export default function TaskView() {
   const parts = task ? splitPrompt(task.prompt) : null;
   const isCorrection = task?.category_code === "correccio";
 
+  const onboardingSteps: OnboardingStep[] = [
+    {
+      ref: headerRef,
+      title: "Què se li ha demanat al model",
+      text: "Aquí veus la categoria de la tasca i la instrucció exacta que s'ha enviat als dos models.",
+    },
+    ...(parts?.source
+      ? [
+          {
+            ref: originalTextRef,
+            title: "Text original",
+            text: "Aquest és el text de partida, tal com el va rebre el model, sense cap correcció.",
+          },
+        ]
+      : []),
+    {
+      ref: responsesRef,
+      title: "Compara les dues respostes",
+      text: "Llegeix la resposta A i la B. No saps quin model ha generat cadascuna: és una avaluació cega.",
+    },
+    {
+      ref: voteRef,
+      title: "Vota",
+      text: "Tria quina resposta és millor, si estan empatades o si cap de les dues és bona. També pots fer servir les dreceres A, B, E i C.",
+    },
+  ];
+
   return (
     <div className="mx-auto max-w-5xl px-4 py-6">
       <h2 className="mb-4 text-2xl font-bold text-brand-600">Avaluació de respostes</h2>
@@ -195,6 +228,18 @@ export default function TaskView() {
         </select>
 
         {progress && <ProgressBar progress={progress} className="flex-1" />}
+
+        {/* Discret a propòsit: aquesta pantalla es repeteix 90+ vegades per
+            avaluador, i el tutorial només cal la primera vegada. */}
+        {task && (
+          <button
+            type="button"
+            onClick={() => setShowOnboarding(true)}
+            className="shrink-0 text-sm text-slate-500 underline hover:text-brand-600"
+          >
+            Tutorial
+          </button>
+        )}
       </div>
 
       {message && (
@@ -209,7 +254,7 @@ export default function TaskView() {
 
       {task && parts && (
         <>
-          <section className="mb-4">
+          <section ref={headerRef} className="mb-4">
             {/* Sense aquestes frases, algú nou podia confondre l'enunciat de sota
                 amb instruccions per a ell mateix, quan en realitat és el que es va
                 demanar als dos models (Jordi, issue #56). Reutilitzem l'estil de
@@ -236,6 +281,9 @@ export default function TaskView() {
           {parts.source &&
             (isCorrection ? (
               <details
+                ref={(el) => {
+                  originalTextRef.current = el;
+                }}
                 open
                 className="mb-4 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3"
               >
@@ -247,7 +295,10 @@ export default function TaskView() {
                 </p>
               </details>
             ) : (
-              <section className="mb-6 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+              <section
+                ref={originalTextRef}
+                className="mb-6 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3"
+              >
                 <h3 className="mb-1 text-sm font-semibold tracking-wide text-slate-500 uppercase">
                   Text original
                 </h3>
@@ -267,7 +318,7 @@ export default function TaskView() {
           {isCorrection && <DiffLegend />}
 
           {/* Apilades al mòbil, en dues columnes a partir de pantalla mitjana. */}
-          <div className="mb-6 grid gap-4 md:grid-cols-2">
+          <div ref={responsesRef} className="mb-6 grid gap-4 md:grid-cols-2">
             <ResponseCard
               label="Resposta A"
               text={task.response_a}
@@ -285,7 +336,7 @@ export default function TaskView() {
               són sempre a l'abast del polze. A partir de `md` tornen al flux normal. */}
           <div className="fixed inset-x-0 bottom-0 z-10 border-t border-slate-200 bg-white/95 px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] backdrop-blur md:static md:border-0 md:bg-transparent md:p-0 md:backdrop-blur-none">
             <div className="mx-auto max-w-5xl">
-              <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+              <div ref={voteRef} className="grid grid-cols-2 gap-2 lg:grid-cols-4">
                 {VOTE_OPTIONS.map((option) => (
                   <button
                     key={option.winner}
@@ -328,6 +379,10 @@ export default function TaskView() {
               </div>
             </div>
           </div>
+
+          {showOnboarding && (
+            <Onboarding steps={onboardingSteps} onDone={() => setShowOnboarding(false)} />
+          )}
         </>
       )}
     </div>

--- a/frontend/src/components/TaskView.tsx
+++ b/frontend/src/components/TaskView.tsx
@@ -29,10 +29,10 @@ export default function TaskView() {
   /** No queden tasques per al filtre actual (el backend ha respost 404). */
   const [exhausted, setExhausted] = useState(false);
   const [showOnboarding, setShowOnboarding] = useState(false);
-  const headerRef = useRef<HTMLElement>(null);
-  const originalTextRef = useRef<HTMLElement>(null);
-  const responsesRef = useRef<HTMLDivElement>(null);
-  const voteRef = useRef<HTMLDivElement>(null);
+  const headerRef = useRef<HTMLElement | null>(null);
+  const originalTextRef = useRef<HTMLElement | null>(null);
+  const responsesRef = useRef<HTMLDivElement | null>(null);
+  const voteRef = useRef<HTMLDivElement | null>(null);
 
   const loadProgress = useCallback(async () => {
     // El progrés és informatiu: si falla, no bloquegem l'avaluació.
@@ -156,7 +156,9 @@ export default function TaskView() {
   // Dreceres de teclat: cada avaluador fa 90 vots o més, i obligar-lo a moure el
   // ratolí fins al botó a cada tasca és una fricció que se suma 90 vegades.
   useEffect(() => {
-    if (locked || !task) return;
+    // Sense aquesta guarda, votar amb tecles funcionaria per sota del
+    // tutorial mentre és obert, sense que la persona ho vegi.
+    if (locked || !task || showOnboarding) return;
 
     function onKeyDown(event: KeyboardEvent) {
       if (event.metaKey || event.ctrlKey || event.altKey) return;
@@ -172,7 +174,7 @@ export default function TaskView() {
 
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [locked, task, resolve]);
+  }, [locked, task, resolve, showOnboarding]);
 
   const parts = task ? splitPrompt(task.prompt) : null;
   const isCorrection = task?.category_code === "correccio";

--- a/frontend/src/components/TaskView.tsx
+++ b/frontend/src/components/TaskView.tsx
@@ -173,6 +173,8 @@ export default function TaskView() {
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-6">
+      <h2 className="mb-4 text-2xl font-bold text-brand-600">Avaluació de respostes</h2>
+
       {/* Filtre i progrés comparteixen línia: dues files senceres abans de la tasca
           empenyien massa avall el text, que és el que s'ha de llegir. El rètol
           «Categoria» desapareix perquè el desplegable ja diu què fa. */}
@@ -208,9 +210,23 @@ export default function TaskView() {
       {task && parts && (
         <>
           <section className="mb-4">
-            <h2 className="mb-1 text-sm font-semibold tracking-wide text-brand-600 uppercase">
-              {CATEGORIES.find((item) => item.code === task.category_code)?.label}
-            </h2>
+            {/* Sense aquestes frases, algú nou podia confondre l'enunciat de sota
+                amb instruccions per a ell mateix, quan en realitat és el que es va
+                demanar als dos models (Jordi, issue #56). Reutilitzem l'estil de
+                «Text original» (mb-1 text-sm font-semibold tracking-wide uppercase)
+                perquè els rètols de la pàgina segueixin un sol llenguatge visual. */}
+            <hr className="mb-4 border-slate-200" />
+            <p className="mb-1 text-sm">
+              <span className="font-semibold tracking-wide text-slate-500 uppercase">
+                Tipus de tasca:
+              </span>{" "}
+              <span className="font-semibold tracking-wide text-slate-700 uppercase">
+                {CATEGORIES.find((item) => item.code === task.category_code)?.label}
+              </span>
+            </p>
+            <h3 className="mb-1 text-sm font-semibold tracking-wide text-slate-500 uppercase">
+              Indicació enviada al model
+            </h3>
             <p className="text-lg text-slate-900">{parts.instruction}</p>
           </section>
 
@@ -238,6 +254,10 @@ export default function TaskView() {
                 <p className="leading-relaxed whitespace-pre-wrap text-slate-800">{parts.source}</p>
               </section>
             ))}
+
+          <p className="mb-3 text-sm text-slate-600">
+            La vostra tasca és avaluar la resposta dels dos models.
+          </p>
 
           {isCorrection && <DiffLegend />}
 

--- a/frontend/src/components/TaskView.tsx
+++ b/frontend/src/components/TaskView.tsx
@@ -220,14 +220,14 @@ export default function TaskView() {
               <span className="font-semibold tracking-wide text-slate-500 uppercase">
                 Tipus de tasca:
               </span>{" "}
-              <span className="font-semibold tracking-wide text-slate-700 uppercase">
+              <span className="text-base font-semibold text-slate-700">
                 {CATEGORIES.find((item) => item.code === task.category_code)?.label}
               </span>
             </p>
             <h3 className="mb-1 text-sm font-semibold tracking-wide text-slate-500 uppercase">
               Indicació enviada al model
             </h3>
-            <p className="text-lg text-slate-900">{parts.instruction}</p>
+            <code className="text-base font-semibold text-slate-700">«{parts.instruction}»</code>
           </section>
 
           {/* A correcció el text es pot plegar: el diff de cada targeta ja el conté, i
@@ -255,8 +255,13 @@ export default function TaskView() {
               </section>
             ))}
 
-          <p className="mb-3 text-sm text-slate-600">
-            La vostra tasca és avaluar la resposta dels dos models.
+          <p className="mb-3 text-sm">
+            <span className="font-semibold tracking-wide text-slate-500 uppercase">
+              La vostra tasca:
+            </span>{" "}
+            <span className="text-base font-semibold text-slate-700">
+              avaluar la resposta dels dos models.
+            </span>
           </p>
 
           {isCorrection && <DiffLegend />}

--- a/frontend/src/components/TaskView.tsx
+++ b/frontend/src/components/TaskView.tsx
@@ -206,7 +206,23 @@ export default function TaskView() {
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-6">
-      <h2 className="mb-4 text-2xl font-bold text-brand-600">Avaluació de respostes</h2>
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h2 className="text-2xl font-bold text-brand-600">Avaluació de respostes</h2>
+
+        {/* Discret a propòsit: aquesta pantalla es repeteix 90+ vegades per
+            avaluador, i el tutorial només cal la primera vegada. Al costat del
+            filtre no hi cabia al mòbil: hi xocava amb el «pendents», que no es
+            pot encongir perquè és `whitespace-nowrap`. */}
+        {task && (
+          <button
+            type="button"
+            onClick={() => setShowOnboarding(true)}
+            className="shrink-0 text-sm text-slate-500 underline hover:text-brand-600"
+          >
+            Tutorial
+          </button>
+        )}
+      </div>
 
       {/* Filtre i progrés comparteixen línia: dues files senceres abans de la tasca
           empenyien massa avall el text, que és el que s'ha de llegir. El rètol
@@ -228,18 +244,6 @@ export default function TaskView() {
         </select>
 
         {progress && <ProgressBar progress={progress} className="flex-1" />}
-
-        {/* Discret a propòsit: aquesta pantalla es repeteix 90+ vegades per
-            avaluador, i el tutorial només cal la primera vegada. */}
-        {task && (
-          <button
-            type="button"
-            onClick={() => setShowOnboarding(true)}
-            className="shrink-0 text-sm text-slate-500 underline hover:text-brand-600"
-          >
-            Tutorial
-          </button>
-        )}
       </div>
 
       {message && (


### PR DESCRIPTION
## Resum

Resposta als comentaris de la Jordi a l'issue #56 sobre la pantalla d'avaluació:

- El consentiment del registre ("Accepto el tractament...") ara enllaça a l'[avís legal](https://www.softcatala.org/avis-legal/).
- Es distingeix explícitament el text que es va enviar al model ("Indicació enviada al model") de la tasca de qui avalua ("La vostra tasca és avaluar la resposta dels dos models"), perquè no es confonguin.
- Nou títol de secció "Avaluació de respostes" i un separador visual abans de la informació de la tasca.

Tanca parcialment #56 (queda pendent el redisseny de la pantalla principal).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] Verificat en viu al navegador amb tasques reals de correcció