### PR TITLE
fix: restaura el proxy local de /api en desenvolupament

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -13,7 +13,7 @@ import type { CategoryFilter, Progress, SessionState, Task, Winner } from "./typ
 
 // `||` i no `??`: una variable definida però buida (cosa fàcil en un fitxer .env)
 // ha de caure igualment al valor per defecte, o les crides perdrien el prefix /api.
-const BASE = import.meta.env.VITE_API_BASE_URL || "https://api.softcatala.org/arena_cat/v1/api";
+const BASE = import.meta.env.VITE_API_BASE_URL || "/api";
 
 /** Error amb el codi HTTP, perquè la interfície pugui distingir 401 de 425 o 409. */
 export class ApiError extends Error {


### PR DESCRIPTION
## Resum

El PR #52 va canviar el fallback de `VITE_API_BASE_URL` a `frontend/src/api.ts`
de l'URL relativa `/api` (que el proxy de Vite reenvia al backend local) a
l'URL de producció codificada directament al codi.

Efecte: qualsevol `npm run dev` local sense `VITE_API_BASE_URL` definida parla
per defecte amb `https://api.softcatala.org`, no amb el backend local. Això
també és un risc, perquè un entorn de desenvolupament pot acabar registrant
usuaris, votant o llegint dades reals de producció sense voler-ho.

`.gitlab-ci.yml` ja passa `VITE_API_BASE_URL` explícitament com a build-arg
del Dockerfile de desplegament, així que el fallback de codi no calia i només
trencava el flux local.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] Verificat que, sense `VITE_API_BASE_URL`, les crides tornen a anar a `127.0.0.1:5173/api/...` (proxy local) en lloc de `api.softcatala.org`