### PR TITLE
feat: afegeix una pàgina pública de rànquing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4",
@@ -808,9 +809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -919,9 +917,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -936,9 +931,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -953,9 +945,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,9 +959,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -987,9 +973,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1004,9 +987,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1021,9 +1001,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1038,9 +1015,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1055,9 +1029,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1072,9 +1043,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1089,9 +1057,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1106,9 +1071,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1123,9 +1085,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1349,9 +1308,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1369,9 +1325,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1389,9 +1342,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1409,9 +1359,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,6 +1624,18 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2022,9 +1981,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2046,9 +2002,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2070,9 +2023,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2094,9 +2044,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2180,9 +2127,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2190,7 +2137,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2304,6 +2250,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "dependencies": {
+        "react-router": "7.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
@@ -2365,6 +2347,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.18.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
+import { Navigate, Route, Routes, useNavigate } from "react-router-dom";
 
 import { api, UNAUTHENTICATED_EVENT } from "./api";
 import logotip from "./assets/softcatala-logotip.png";
 import Login from "./components/Login";
+import RankingView from "./components/RankingView";
 import TaskView from "./components/TaskView";
 import { clearTask } from "./taskStore";
 import type { SessionState } from "./types";
@@ -13,6 +15,7 @@ export default function App() {
   // `null` mentre no sabem si hi ha sessió: sense aquest estat intermedi
   // ensenyaríem el formulari un instant a qui ja té la sessió oberta.
   const [session, setSession] = useState<SessionState | null>(null);
+  const navigate = useNavigate();
 
   const refresh = useCallback(async () => {
     try {
@@ -43,7 +46,10 @@ export default function App() {
 
   function logout() {
     clearTask();
-    void api.logout().finally(() => setSession(UNKNOWN));
+    void api.logout().finally(() => {
+      setSession(UNKNOWN);
+      navigate("/login");
+    });
   }
 
   return (
@@ -78,10 +84,26 @@ export default function App() {
       <main>
         {session === null ? (
           <p className="px-4 py-10 text-center text-slate-500">Carregant…</p>
-        ) : session.authenticated ? (
-          <TaskView />
         ) : (
-          <Login onLoggedIn={refresh} />
+          <Routes>
+            <Route
+              path="/login"
+              element={
+                session.authenticated ? <Navigate to="/" replace /> : <Login onLoggedIn={refresh} />
+              }
+            />
+            <Route
+              path="/"
+              element={
+                session.authenticated ? (
+                  <TaskView />
+                ) : (
+                  <RankingView onLogin={() => navigate("/login")} />
+                )
+              }
+            />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
         )}
       </main>
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,7 +9,7 @@
  */
 
 import { readDetail, readErrorCode, TASK_TOKEN_INVALID } from "./errors";
-import type { CategoryFilter, Progress, SessionState, Task, Winner } from "./types";
+import type { CategoryFilter, Progress, Ranking, SessionState, Task, Winner } from "./types";
 
 // `||` i no `??`: una variable definida però buida (cosa fàcil en un fitxer .env)
 // ha de caure igualment al valor per defecte, o les crides perdrien el prefix /api.
@@ -89,6 +89,12 @@ export const api = {
     }),
 
   progress: () => request<Progress>("/task/progress"),
+
+  // Públic: no cal sessió per veure el rànquing.
+  ranking: (category: CategoryFilter) =>
+    request<Ranking>(
+      category ? `/ranking?category_code=${encodeURIComponent(category)}` : "/ranking",
+    ),
 
   vote: (token: string, winner: Winner) =>
     request<{ status: string }>("/vote", {

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 import { api, ApiError } from "../api";
 
@@ -145,6 +146,15 @@ export default function Login({ onLoggedIn }: { onLoggedIn: () => void }) {
           {isRegister ? "Inicia la sessió" : "Crea'n un"}
         </button>
       </p>
+
+      <hr className="my-6 border-slate-200" />
+
+      <Link
+        to="/"
+        className="block w-full rounded-md border border-slate-300 px-4 py-2 text-center font-medium text-slate-700 hover:border-brand-500 hover:text-brand-600"
+      >
+        Consulta el rànquing
+      </Link>
     </div>
   );
 }

--- a/frontend/src/components/RankingView.tsx
+++ b/frontend/src/components/RankingView.tsx
@@ -11,6 +11,9 @@ export default function RankingView({ onLogin }: { onLogin: () => void }) {
   useEffect(() => {
     let cancelled = false;
     setMessage(null);
+    // Sense això, en canviar de categoria es veuria un instant la capçalera
+    // nova amb la taula encara plena de dades de l'anterior.
+    setRanking(null);
     void api
       .ranking(category)
       .then((next) => {
@@ -40,6 +43,7 @@ export default function RankingView({ onLogin }: { onLogin: () => void }) {
           <button
             key={item.code}
             type="button"
+            aria-pressed={category === item.code}
             onClick={() => setCategory(item.code)}
             className={
               category === item.code

--- a/frontend/src/components/RankingView.tsx
+++ b/frontend/src/components/RankingView.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useState } from "react";
+
+import { api, ApiError } from "../api";
+import { CATEGORIES, type CategoryFilter, type Ranking } from "../types";
+
+export default function RankingView({ onLogin }: { onLogin: () => void }) {
+  const [category, setCategory] = useState<CategoryFilter>("");
+  const [ranking, setRanking] = useState<Ranking | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setMessage(null);
+    void api
+      .ranking(category)
+      .then((next) => {
+        if (!cancelled) setRanking(next);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setRanking(null);
+        setMessage(err instanceof ApiError ? err.message : "Error de connexió");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [category]);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <h2 className="mb-1 text-2xl font-bold text-slate-900">
+        La lliga dels models d'IA en català
+      </h2>
+      <p className="mb-5 text-slate-500">
+        Marcador públic, duels anònims i rànquing recalculat amb cada vot.
+      </p>
+
+      <div className="mb-5 inline-flex flex-wrap gap-1 rounded-md border border-slate-200 bg-white p-1">
+        {CATEGORIES.map((item) => (
+          <button
+            key={item.code}
+            type="button"
+            onClick={() => setCategory(item.code)}
+            className={
+              category === item.code
+                ? "rounded bg-brand-500 px-3 py-1.5 text-sm font-medium text-white"
+                : "rounded px-3 py-1.5 text-sm font-medium text-slate-600 hover:bg-slate-100"
+            }
+          >
+            {item.code === "" ? "Global" : item.label}
+          </button>
+        ))}
+      </div>
+
+      {message && (
+        <p role="status" className="mb-4 rounded-md bg-amber-50 px-4 py-3 text-amber-900">
+          {message}
+        </p>
+      )}
+
+      {ranking && (
+        <>
+          <section className="mb-4 overflow-hidden rounded-lg border border-slate-200">
+            <header className="flex items-center justify-between bg-brand-600 px-5 py-3">
+              <div>
+                <h3 className="font-semibold text-white">Rànquing en directe</h3>
+                <p className="text-sm text-brand-100">
+                  {category === ""
+                    ? "Global"
+                    : CATEGORIES.find((item) => item.code === category)?.label}
+                  {" · "}actualitzat amb els vots de la comunitat
+                </p>
+              </div>
+              {!ranking.confidence.is_stable && (
+                <span className="shrink-0 rounded-full bg-amber-100 px-2.5 py-1 text-xs font-semibold text-amber-800">
+                  Provisional
+                </span>
+              )}
+            </header>
+
+            <table className="w-full text-left">
+              <thead>
+                <tr className="text-xs font-semibold tracking-wide text-slate-500 uppercase">
+                  <th className="px-5 py-2">Posició</th>
+                  <th className="px-5 py-2">Model</th>
+                  <th className="px-5 py-2 text-right">Puntuació</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ranking.ranked_models.map((item) => (
+                  <tr
+                    key={item.model}
+                    className={
+                      item.model === ranking.best_model
+                        ? "border-t border-slate-100 bg-brand-50"
+                        : "border-t border-slate-100"
+                    }
+                  >
+                    <td className="px-5 py-3">
+                      <span
+                        className={
+                          item.model === ranking.best_model
+                            ? "flex h-7 w-7 items-center justify-center rounded-full bg-brand-500 text-sm font-semibold text-white"
+                            : "flex h-7 w-7 items-center justify-center rounded-full bg-slate-100 text-sm font-semibold text-slate-600"
+                        }
+                      >
+                        {item.rank}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3 font-medium text-slate-800">{item.model}</td>
+                    <td className="px-5 py-3 text-right font-mono text-slate-700">
+                      {item.bt_skill >= 0 ? "+" : ""}
+                      {item.bt_skill.toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+                {ranking.ranked_models.length === 0 && (
+                  <tr>
+                    <td colSpan={3} className="px-5 py-6 text-center text-slate-500">
+                      Encara no hi ha prou vots per calcular el rànquing.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+
+            <div className="grid grid-cols-2 gap-4 border-t border-slate-200 px-5 py-4 sm:grid-cols-4">
+              <Stat label="Vots" value={ranking.n_votes_total} />
+              <Stat label="Decisius" value={ranking.n_votes_decisive} />
+              <Stat label="Empats" value={ranking.n_ties} />
+              <Stat label="Cap de les dues" value={ranking.n_neither} />
+            </div>
+
+            <div className="flex items-center justify-between border-t border-slate-200 px-5 py-3 text-sm">
+              <span className="text-slate-500">Confiança del líder</span>
+              <span className="font-semibold text-slate-700">
+                {Math.round(ranking.confidence.p_best_is_best * 100)}%
+              </span>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-brand-100 bg-brand-50 px-5 py-4 text-center">
+            <p className="mb-3 text-slate-700">
+              Fes que el rànquing sigui més fiable: cada comparació ajuda a saber quins models
+              responen millor en català.
+            </p>
+            <button
+              type="button"
+              onClick={onLogin}
+              className="rounded-md bg-brand-500 px-5 py-2 font-medium text-white hover:bg-brand-600"
+            >
+              Entra o crea un compte per avaluar
+            </button>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <p className="text-xs font-semibold tracking-wide text-slate-500 uppercase">{label}</p>
+      <p className="text-lg font-semibold text-slate-800">{value}</p>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 
 import App from "./App";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,3 +38,31 @@ export interface Progress {
 }
 
 export type Winner = "a" | "b" | "tie" | "neither";
+
+export interface RankedModel {
+  rank: number;
+  model: string;
+  bt_skill: number;
+}
+
+export interface RankingConfidence {
+  category_code: CategoryCode | null;
+  best_model: string | null;
+  n_prompts: number;
+  n_decisive_votes: number;
+  p_best_is_best: number;
+  confidence_interval: { lo: number; hi: number };
+  is_stable: boolean;
+}
+
+/** Resposta de `GET /api/ranking`. */
+export interface Ranking {
+  category_code: CategoryCode | null;
+  n_votes_total: number;
+  n_votes_decisive: number;
+  n_ties: number;
+  n_neither: number;
+  best_model: string | null;
+  ranked_models: RankedModel[];
+  confidence: RankingConfidence;
+}


### PR DESCRIPTION
## Resum
- Nova pàgina pública amb el rànquing en directe (`GET /api/ranking`): passa a ser la pàgina d'entrada per a qui no ha iniciat sessió.
- Filtre per categoria (Global / Correcció / Reformulació / Traducció), taula amb posició/model/puntuació, estadístiques de vots i indicador «Provisional» quan el rànquing encara no és estadísticament estable (`confidence.is_stable`).
- El formulari de login es converteix en un botó/CTA des de la pàgina de rànquing, en lloc de mostrar-se sencer.
- S'afegeix encaminament amb `react-router-dom` perquè `/login` sigui una URL real, recarregable i desable a preferits; en tancar la sessió es torna a `/login`.
- Botó "Consulta el rànquing" al formulari de login per tornar-hi.

Nota: aquesta branca surt de `main` (no de `feat/ui-avaluacio-millores`) perquè és una funcionalitat independent de les PR #59 i #60, encara obertes.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] Provat en local: rànquing es mostra sense sessió, filtre per categoria funciona, botó porta a `/login`, login redirigeix a `/`, `/login` és recarregable directament, tancar sessió torna a `/login`.