### PR TITLE
feat: afegeix un tutorial de la pantalla d'avaluació

### DIFF
--- a/frontend/src/components/Onboarding.tsx
+++ b/frontend/src/components/Onboarding.tsx
@@ -1,0 +1,97 @@
+import { useLayoutEffect, useState, type RefObject } from "react";
+
+export interface OnboardingStep {
+  ref: RefObject<HTMLElement | null>;
+  title: string;
+  text: string;
+}
+
+const TOOLTIP_WIDTH = 288;
+const GAP = 12;
+
+/** Tutorial de primer ús: assenyala, un per un, els blocs clau de la pantalla d'avaluació. */
+export default function Onboarding({
+  steps,
+  onDone,
+}: {
+  steps: OnboardingStep[];
+  onDone: () => void;
+}) {
+  const [index, setIndex] = useState(0);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const step = steps[index];
+
+  useLayoutEffect(() => {
+    const target = step.ref.current;
+    if (!target) return;
+
+    target.scrollIntoView({ block: "center", behavior: "smooth" });
+
+    const update = () => setRect(target.getBoundingClientRect());
+    update();
+    // El `scrollIntoView` és animat: recalculem un cop acabat perquè el
+    // requadre no quedi assenyalant la posició d'abans de l'scroll.
+    const afterScroll = setTimeout(update, 350);
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+    return () => {
+      clearTimeout(afterScroll);
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+    };
+  }, [step]);
+
+  function next() {
+    if (index === steps.length - 1) onDone();
+    else setIndex(index + 1);
+  }
+
+  if (!rect) return null;
+
+  const pad = 8;
+  const spaceBelow = window.innerHeight - rect.bottom;
+  const tooltipTop =
+    spaceBelow > 200 ? rect.bottom + pad + GAP : Math.max(GAP, rect.top - pad - GAP - 180);
+  const tooltipLeft = Math.min(Math.max(GAP, rect.left), window.innerWidth - TOOLTIP_WIDTH - GAP);
+
+  return (
+    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true" aria-label="Tutorial">
+      <div
+        className="pointer-events-none absolute rounded-lg transition-all duration-300"
+        style={{
+          top: rect.top - pad,
+          left: rect.left - pad,
+          width: rect.width + pad * 2,
+          height: rect.height + pad * 2,
+          boxShadow: "0 0 0 9999px rgba(15, 23, 42, 0.65)",
+        }}
+      />
+      <div
+        className="absolute rounded-lg bg-white p-4 shadow-xl transition-all duration-300"
+        style={{ top: tooltipTop, left: tooltipLeft, width: TOOLTIP_WIDTH }}
+      >
+        <p className="mb-1 text-xs font-semibold tracking-wide text-brand-600 uppercase">
+          Pas {index + 1} de {steps.length}
+        </p>
+        <h3 className="mb-1 font-semibold text-slate-900">{step.title}</h3>
+        <p className="mb-3 text-sm text-slate-600">{step.text}</p>
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onDone}
+            className="text-sm text-slate-500 underline hover:text-slate-700"
+          >
+            Omet el tutorial
+          </button>
+          <button
+            type="button"
+            onClick={next}
+            className="rounded-md bg-brand-500 px-3 py-1.5 text-sm font-medium text-white hover:bg-brand-600"
+          >
+            {index === steps.length - 1 ? "Entesos" : "Següent"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskView.tsx
+++ b/frontend/src/components/TaskView.tsx
@@ -4,6 +4,7 @@ import { api, ApiError } from "../api";
 import { splitPrompt } from "../diff";
 import { clearTask, loadSavedTask, saveTask, secondsUntilVote } from "../taskStore";
 import { CATEGORIES, type CategoryFilter, type Progress, type Task, type Winner } from "../types";
+import Onboarding, { type OnboardingStep } from "./Onboarding";
 import ProgressBar from "./ProgressBar";
 import ResponseCard from "./ResponseCard";
 
@@ -27,6 +28,11 @@ export default function TaskView() {
   const [remaining, setRemaining] = useState(0);
   /** No queden tasques per al filtre actual (el backend ha respost 404). */
   const [exhausted, setExhausted] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
+  const headerRef = useRef<HTMLElement>(null);
+  const originalTextRef = useRef<HTMLElement>(null);
+  const responsesRef = useRef<HTMLDivElement>(null);
+  const voteRef = useRef<HTMLDivElement>(null);
 
   const loadProgress = useCallback(async () => {
     // El progrés és informatiu: si falla, no bloquegem l'avaluació.
@@ -171,6 +177,33 @@ export default function TaskView() {
   const parts = task ? splitPrompt(task.prompt) : null;
   const isCorrection = task?.category_code === "correccio";
 
+  const onboardingSteps: OnboardingStep[] = [
+    {
+      ref: headerRef,
+      title: "Què se li ha demanat al model",
+      text: "Aquí veus la categoria de la tasca i la instrucció exacta que s'ha enviat als dos models.",
+    },
+    ...(parts?.source
+      ? [
+          {
+            ref: originalTextRef,
+            title: "Text original",
+            text: "Aquest és el text de partida, tal com el va rebre el model, sense cap correcció.",
+          },
+        ]
+      : []),
+    {
+      ref: responsesRef,
+      title: "Compara les dues respostes",
+      text: "Llegeix la resposta A i la B. No saps quin model ha generat cadascuna: és una avaluació cega.",
+    },
+    {
+      ref: voteRef,
+      title: "Vota",
+      text: "Tria quina resposta és millor, si estan empatades o si cap de les dues és bona. També pots fer servir les dreceres A, B, E i C.",
+    },
+  ];
+
   return (
     <div className="mx-auto max-w-5xl px-4 py-6">
       {/* Filtre i progrés comparteixen línia: dues files senceres abans de la tasca
@@ -193,6 +226,18 @@ export default function TaskView() {
         </select>
 
         {progress && <ProgressBar progress={progress} className="flex-1" />}
+
+        {/* Discret a propòsit: aquesta pantalla es repeteix 90+ vegades per
+            avaluador, i el tutorial només cal la primera vegada. */}
+        {task && (
+          <button
+            type="button"
+            onClick={() => setShowOnboarding(true)}
+            className="shrink-0 text-sm text-slate-500 underline hover:text-brand-600"
+          >
+            Tutorial
+          </button>
+        )}
       </div>
 
       {message && (
@@ -207,7 +252,7 @@ export default function TaskView() {
 
       {task && parts && (
         <>
-          <section className="mb-4">
+          <section ref={headerRef} className="mb-4">
             <h2 className="mb-1 text-sm font-semibold tracking-wide text-brand-600 uppercase">
               {CATEGORIES.find((item) => item.code === task.category_code)?.label}
             </h2>
@@ -220,6 +265,9 @@ export default function TaskView() {
           {parts.source &&
             (isCorrection ? (
               <details
+                ref={(el) => {
+                  originalTextRef.current = el;
+                }}
                 open
                 className="mb-4 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3"
               >
@@ -231,7 +279,10 @@ export default function TaskView() {
                 </p>
               </details>
             ) : (
-              <section className="mb-6 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
+              <section
+                ref={originalTextRef}
+                className="mb-6 rounded-lg border border-slate-200 bg-slate-50 px-4 py-3"
+              >
                 <h3 className="mb-1 text-sm font-semibold tracking-wide text-slate-500 uppercase">
                   Text original
                 </h3>
@@ -242,7 +293,7 @@ export default function TaskView() {
           {isCorrection && <DiffLegend />}
 
           {/* Apilades al mòbil, en dues columnes a partir de pantalla mitjana. */}
-          <div className="mb-6 grid gap-4 md:grid-cols-2">
+          <div ref={responsesRef} className="mb-6 grid gap-4 md:grid-cols-2">
             <ResponseCard
               label="Resposta A"
               text={task.response_a}
@@ -260,7 +311,7 @@ export default function TaskView() {
               són sempre a l'abast del polze. A partir de `md` tornen al flux normal. */}
           <div className="fixed inset-x-0 bottom-0 z-10 border-t border-slate-200 bg-white/95 px-4 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] backdrop-blur md:static md:border-0 md:bg-transparent md:p-0 md:backdrop-blur-none">
             <div className="mx-auto max-w-5xl">
-              <div className="grid grid-cols-2 gap-2 lg:grid-cols-4">
+              <div ref={voteRef} className="grid grid-cols-2 gap-2 lg:grid-cols-4">
                 {VOTE_OPTIONS.map((option) => (
                   <button
                     key={option.winner}
@@ -303,6 +354,10 @@ export default function TaskView() {
               </div>
             </div>
           </div>
+
+          {showOnboarding && (
+            <Onboarding steps={onboardingSteps} onDone={() => setShowOnboarding(false)} />
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## Resum
- Tutorial guiat de 4 passos a la pantalla d'avaluació: assenyala l'enunciat de la tasca, el text original (a correcció), les respostes A/B i els botons de vot.
- No es mostra automàticament: apareix només quan algú clica l'enllaç «Tutorial», al costat del filtre de categoria, i es pot tornar a obrir tantes vegades com es vulgui.

Aquesta branca surt de `feat/pagina-ranquing` (PR #61) perquè fa servir `RankingView`/routing d'aquella PR. Cal revisar-la i fusionar-la després de la #61.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] Provat en local: els 4 passos assenyalen l'element correcte i fan scroll fins a ell, «Omet el tutorial» i «Entesos» el tanquen, l'enllaç «Tutorial» el torna a obrir en qualsevol moment.